### PR TITLE
chore: reduce limit of CPU and Memory

### DIFF
--- a/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
@@ -41,8 +41,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -62,8 +62,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -79,8 +79,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -124,8 +124,8 @@ spec:
               name: msi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
@@ -34,8 +34,8 @@ spec:
             - --v=5
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -61,8 +61,8 @@ spec:
               mountPath: /registration
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -120,8 +120,8 @@ spec:
               name: blob-cache
           resources:
             limits:
-              cpu: 4
-              memory: 6Gi
+              cpu: 800m
+              memory: 800Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/deploy/csi-blob-controller.yaml
+++ b/deploy/csi-blob-controller.yaml
@@ -40,8 +40,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -60,8 +60,8 @@ spec:
               name: socket-dir
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -76,8 +76,8 @@ spec:
               mountPath: /csi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -121,8 +121,8 @@ spec:
               name: msi
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 200m
+              memory: 200Mi
             requests:
               cpu: 10m
               memory: 20Mi

--- a/deploy/csi-blob-node.yaml
+++ b/deploy/csi-blob-node.yaml
@@ -33,8 +33,8 @@ spec:
             - --v=5
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -60,8 +60,8 @@ spec:
               mountPath: /registration
           resources:
             limits:
-              cpu: 1
-              memory: 1Gi
+              cpu: 100m
+              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -119,8 +119,8 @@ spec:
               name: blob-cache
           resources:
             limits:
-              cpu: 4
-              memory: 6Gi
+              cpu: 800m
+              memory: 800Mi
             requests:
               cpu: 10m
               memory: 20Mi


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Set the reasonable CPU and Memory.

- Reduce limit of azurefile container CPU and Memory to one fifth.
- 
- Reduce limit of sidecar containers CPU and Memory to one tenth.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Use `kubectl top pod` command to get the usage data.
```
POD                                    NAME              CPU(cores)   MEMORY(bytes)   
csi-blob-controller-59f965c9b9-58lf4   csi-attacher      1m           8Mi             
csi-blob-controller-59f965c9b9-58lf4   csi-provisioner   1m           9Mi             
csi-blob-controller-59f965c9b9-58lf4   liveness-probe    1m           4Mi             
csi-blob-controller-59f965c9b9-58lf4   blob              1m           8Mi
```
```
POD                   NAME                    CPU(cores)   MEMORY(bytes)   
csi-blob-node-6p5dn   blob                    1m           8Mi             
csi-blob-node-6p5dn   node-driver-registrar   0m           7Mi             
csi-blob-node-6p5dn   liveness-probe          1m           9Mi 
```

Enter the node where the pods run. Then use `top -p <pid>` to get the usage data.
```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND 
 2648 root      20   0  717.6m  27.2m  18.7m S   0.3  0.4   0:00.26 csi-attacher
 2522 root      20   0  136.8m  29.0m  20.3m S   0.0  0.4   0:00.23 csi-provisioner
 2879 root      20   0  136.4m  28.0m  19.6m S   0.0  0.4   0:00.08 blobplugin
 2739 root      20   0  110.4m   7.6m   3.3m S   0.0  0.1   0:00.03 livenessprobe 
```
```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
 2499 root      20   0  113200  15012   6536 S   0.0  0.2   0:00.06 livenessprobe
 2625 root      20   0  112248   9996   3620 S   0.0  0.1   0:00.01 csi-node-driver
 2810 root      20   0  139632  30792  22092 S   0.0  0.4   0:00.08 blobplugin
```

**Release note**:
```
none
```
