### PR TITLE
feat: bring your own account key for dynamic provisioning

### DIFF
--- a/deploy/example/storageclass-blob-secret.yaml
+++ b/deploy/example/storageclass-blob-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: blob
+provisioner: blob.csi.azure.com
+parameters:
+  csi.storage.k8s.io/provisioner-secret-name: azure-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: azure-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: default

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -433,3 +433,34 @@ func isSupportedProtocol(protocol string) bool {
 	}
 	return false
 }
+
+// get storage account from secrets map
+func getStorageAccount(secrets map[string]string) (string, string, error) {
+	if secrets == nil {
+		return "", "", fmt.Errorf("unexpected: getStorageAccount secrets is nil")
+	}
+
+	var accountName, accountKey string
+	for k, v := range secrets {
+		switch strings.ToLower(k) {
+		case "accountname":
+			accountName = v
+		case "azurestorageaccountname": // for compatibility with built-in azurefile plugin
+			accountName = v
+		case "accountkey":
+			accountKey = v
+		case "azurestorageaccountkey": // for compatibility with built-in azurefile plugin
+			accountKey = v
+		}
+	}
+
+	if accountName == "" {
+		return "", "", fmt.Errorf("could not find accountname or azurestorageaccountname field secrets(%v)", secrets)
+	}
+	if accountKey == "" {
+		return "", "", fmt.Errorf("could not find accountkey or azurestorageaccountkey field in secrets(%v)", secrets)
+	}
+
+	klog.V(4).Infof("got storage account(%s) from secret", accountName)
+	return accountName, accountKey, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: bring your own account key

In some scenarios, user's cluster does not have permission to a storage account(in some case, the storage account is in another subscription), we already provide static provisioning for that scenario. While that's not enough, user still wants to only bring own storage account key and driver could provide storage class support(dynamic provisioning).

CSI driver already supports specifying secret in every CSI methods.

 - create `azure-secret` to store account name & key
```
kubectl create secret generic azure-secret --from-literal accountname=NAME --from-literal accountkey="KEY" --type=Opaque
```
 - create azure file storage class referencing `azure-secret` in create/delete/mount process:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: blob
provisioner: blob.csi.azure.com
parameters:
  csi.storage.k8s.io/provisioner-secret-name: azure-secret
  csi.storage.k8s.io/provisioner-secret-namespace: default
  csi.storage.k8s.io/node-stage-secret-name: azure-secret
  csi.storage.k8s.io/node-stage-secret-namespace: default
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
