### PR TITLE
fix: increase CPU limit for throttling issue

### DIFF
--- a/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
@@ -121,7 +121,7 @@ spec:
               name: blob-cache
           resources:
             limits:
-              cpu: 200m
+              cpu: 2
               memory: 2100Mi
             requests:
               cpu: 10m

--- a/deploy/csi-blob-node.yaml
+++ b/deploy/csi-blob-node.yaml
@@ -119,7 +119,7 @@ spec:
               name: blob-cache
           resources:
             limits:
-              cpu: 200m
+              cpu: 2
               memory: 2100Mi
             requests:
               cpu: 10m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: increase CPU limit for throttling issue

as I tested, following `dd` test could consume around 200% CPU, original `200m` limit setting could cause CPU throttling.

```console
# k exec -it statefulset-blob-0 sh
# cd /mnt/blob
# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay         124G   12G  113G  10% /
tmpfs            64M     0   64M   0% /dev
tmpfs            16G     0   16G   0% /sys/fs/cgroup
blobfuse        197G  2.1G  185G   2% /mnt/blob
/dev/sda1       124G   12G  113G  10% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs            16G   12K   16G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs            16G     0   16G   0% /proc/acpi
tmpfs            16G     0   16G   0% /proc/scsi
tmpfs            16G     0   16G   0% /sys/firmware
# cd /mnt/blob
# for i in 1 2 3 4 5; do dd if=/dev/zero of=tempfile bs=1M count=1024; echo '---';done
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 4.50365 s, 238 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 4.524 s, 237 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 4.38287 s, 245 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 4.43193 s, 242 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 4.48506 s, 239 MB/s
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

 - test result without fix
```
# for i in 1 2 3 4 5; do dd if=/dev/zero of=tempfile bs=1M count=1024; echo '---';done
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 30.2738 s, 35.5 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 16.7136 s, 64.2 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 16.9845 s, 63.2 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 16.8181 s, 63.8 MB/s
---
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 16.4016 s, 65.5 MB/s
```

**Release note**:
```
fix: increase CPU limit for throttling issue
```
