### PR TITLE
Revert "fix: create nonroot user in Dockerfile"

### DIFF
--- a/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
@@ -96,8 +96,6 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           imagePullPolicy: {{ .Values.image.blob.pullPolicy }}
-          securityContext:
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
@@ -106,7 +106,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-blob-controller.yaml
+++ b/deploy/csi-blob-controller.yaml
@@ -93,8 +93,6 @@ spec:
                   optional: true
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
-          securityContext:
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/deploy/csi-blob-node.yaml
+++ b/deploy/csi-blob-node.yaml
@@ -104,7 +104,6 @@ spec:
                   fieldPath: spec.nodeName
           securityContext:
             privileged: true
-            runAsUser: 0
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/pkg/blobplugin/Dockerfile
+++ b/pkg/blobplugin/Dockerfile
@@ -30,8 +30,4 @@ RUN apt update && apt install nfs-common nfs-kernel-server -y || true
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Blob Storage CSI driver"
 
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
-
 ENTRYPOINT ["/blobplugin"]

--- a/pkg/blobplugin/dev.Dockerfile
+++ b/pkg/blobplugin/dev.Dockerfile
@@ -18,9 +18,5 @@ RUN dpkg -i /tmp/packages-microsoft-prod.deb && apt-get update && apt-get instal
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Blob Storage CSI driver"
 
-# Create a nonroot user
-RUN useradd -u 10001 nonroot
-USER nonroot
-
 COPY ./_output/blobplugin /blobplugin
 ENTRYPOINT ["/blobplugin"]


### PR DESCRIPTION
Reverts kubernetes-sigs/blob-csi-driver#252

Original PR did not improve the security, that PR is just for bypass security scanning, while would introduce various permission setting issue.