### PR TITLE
chore: upgrade resizer to v1.1.0

### DIFF
--- a/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
@@ -122,6 +122,7 @@ spec:
             - "-csi-address=$(ADDRESS)"
             - "-v=5"
             - "-leader-election"
+            - '-handle-volume-inuse-error=false'
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/charts/latest/blob-csi-driver/values.yaml
+++ b/charts/latest/blob-csi-driver/values.yaml
@@ -17,7 +17,7 @@ image:
     pullPolicy: IfNotPresent
   csiResizer:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer
-    tag: v0.5.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 
 serviceAccount:

--- a/deploy/csi-blob-controller.yaml
+++ b/deploy/csi-blob-controller.yaml
@@ -111,11 +111,12 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-resizer
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v0.5.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.1.0
           args:
             - "-csi-address=$(ADDRESS)"
             - "-v=5"
             - "-leader-election"
+            - '-handle-volume-inuse-error=false'
           env:
             - name: ADDRESS
               value: /csi/csi.sock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
chore: upgrade resizer to v1.1.0

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```
--handle-volume-inuse-error <true/false>: Enable or disable volume-in-use error handling in external-resizer. Defaults to true and resize-controller will watch for all pods in all namespaces to check if PVC being expanded is in-use by a pod or not before retrying volume expansion if CSI driver throws volume-in-use error. Setting this to false will cause external-resizer to ignore volume-in-use error and resize-controller will retry volume expansion even if volume is already in use by a pod and CSI driver does not support expansion of in-use volumes. If CSI driver being used supports online expansion, it might be desirable to set handle-volume-inuse-error to false - to save costs associated with watching all pods in the cluster.
```

**Release note**:
```
chore: upgrade resizer to v1.1.0
```
