### PR TITLE
fix: reduce driver logs

### DIFF
--- a/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-controller.yaml
@@ -32,7 +32,7 @@ spec:
         - name: csi-provisioner
           image: {{ .Values.image.csiProvisioner.repository }}:{{ .Values.image.csiProvisioner.tag }}
           args:
-            - "-v=5"
+            - "-v=2"
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
@@ -127,7 +127,7 @@ spec:
           image: "{{ .Values.image.csiResizer.repository }}:{{ .Values.image.csiResizer.tag }}"
           args:
             - "-csi-address=$(ADDRESS)"
-            - "-v=5"
+            - "-v=2"
             - "-leader-election"
             - '-handle-volume-inuse-error=false'
           env:

--- a/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
+++ b/charts/latest/blob-csi-driver/templates/csi-blob-node.yaml
@@ -42,7 +42,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29633
-            - --v=5
+            - --v=2
           resources:
             limits:
               cpu: 100m
@@ -55,7 +55,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - --v=2
           lifecycle:
             preStop:
               exec:

--- a/deploy/csi-blob-controller.yaml
+++ b/deploy/csi-blob-controller.yaml
@@ -28,7 +28,7 @@ spec:
         - name: csi-provisioner
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v1.4.0
           args:
-            - "-v=5"
+            - "-v=2"
             - "--csi-address=$(ADDRESS)"
             - "--enable-leader-election"
             - "--leader-election-type=leases"
@@ -112,7 +112,7 @@ spec:
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.1.0
           args:
             - "-csi-address=$(ADDRESS)"
-            - "-v=5"
+            - "-v=2"
             - "-leader-election"
             - '-handle-volume-inuse-error=false'
           env:

--- a/deploy/csi-blob-node.yaml
+++ b/deploy/csi-blob-node.yaml
@@ -40,7 +40,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29633
-            - --v=5
+            - --v=2
           resources:
             limits:
               cpu: 100m
@@ -53,7 +53,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - --v=2
           lifecycle:
             preStop:
               exec:

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -310,8 +310,6 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 
 // ControllerGetCapabilities returns the capabilities of the Controller plugin
 func (d *Driver) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ControllerGetCapabilities")
-
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: d.Cap,
 	}, nil

--- a/pkg/csi-common/controllerserver-default.go
+++ b/pkg/csi-common/controllerserver-default.go
@@ -17,8 +17,6 @@ limitations under the License.
 package csicommon
 
 import (
-	"k8s.io/klog/v2"
-
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -46,8 +44,6 @@ func (cs *DefaultControllerServer) ControllerUnpublishVolume(ctx context.Context
 }
 
 func (cs *DefaultControllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ValidateVolumeCapabilities")
-
 	for _, c := range req.GetVolumeCapabilities() {
 		found := false
 		for _, c1 := range cs.Driver.VC {
@@ -77,8 +73,6 @@ func (cs *DefaultControllerServer) GetCapacity(ctx context.Context, req *csi.Get
 // ControllerGetCapabilities implements the default GRPC callout.
 // Default supports all capabilities
 func (cs *DefaultControllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default ControllerGetCapabilities")
-
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: cs.Driver.Cap,
 	}, nil

--- a/pkg/csi-common/driver_test.go
+++ b/pkg/csi-common/driver_test.go
@@ -71,7 +71,6 @@ func TestAddControllerServiceCapabilities(t *testing.T) {
 }
 
 func TestGetVolumeCapabilityAccessModes(t *testing.T) {
-
 	d := NewFakeDriver()
 
 	// Test no volume access modes.

--- a/pkg/csi-common/identityserver-default.go
+++ b/pkg/csi-common/identityserver-default.go
@@ -21,7 +21,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 type DefaultIdentityServer struct {
@@ -29,8 +28,6 @@ type DefaultIdentityServer struct {
 }
 
 func (ids *DefaultIdentityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	klog.V(5).Infof("Using default GetPluginInfo")
-
 	if ids.Driver.Name == "" {
 		return nil, status.Error(codes.Unavailable, "Driver name not configured")
 	}
@@ -50,7 +47,6 @@ func (ids *DefaultIdentityServer) Probe(ctx context.Context, req *csi.ProbeReque
 }
 
 func (ids *DefaultIdentityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	klog.V(5).Infof("Using default capabilities")
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{

--- a/pkg/csi-common/nodeserver-default.go
+++ b/pkg/csi-common/nodeserver-default.go
@@ -19,7 +19,6 @@ package csicommon
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
-	"k8s.io/klog/v2"
 )
 
 type DefaultNodeServer struct {
@@ -27,16 +26,12 @@ type DefaultNodeServer struct {
 }
 
 func (ns *DefaultNodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	klog.V(5).Infof("Using default NodeGetInfo")
-
 	return &csi.NodeGetInfoResponse{
 		NodeId: ns.Driver.NodeID,
 	}, nil
 }
 
 func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	klog.V(2).Infof("Using default NodeGetCapabilities")
-
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: ns.Driver.NSCap,
 	}, nil

--- a/pkg/csi-common/server.go
+++ b/pkg/csi-common/server.go
@@ -68,7 +68,6 @@ func (s *nonBlockingGRPCServer) ForceStop() {
 }
 
 func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer, testMode bool) {
-
 	proto, addr, err := ParseEndpoint(endpoint)
 	if err != nil {
 		klog.Fatal(err.Error())

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -88,7 +88,6 @@ func RunNodePublishServer(endpoint string, d *CSIDriver, ns csi.NodeServer, test
 
 func RunControllerPublishServer(endpoint string, d *CSIDriver, cs csi.ControllerServer, testMode bool) {
 	ids := NewDefaultIdentityServer(d)
-
 	s := NewNonBlockingGRPCServer()
 	s.Start(endpoint, ids, cs, nil, testMode)
 	s.Wait()

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -81,7 +81,6 @@ func NewNodeServiceCapability(cap csi.NodeServiceCapability_RPC_Type) *csi.NodeS
 
 func RunNodePublishServer(endpoint string, d *CSIDriver, ns csi.NodeServer, testMode bool) {
 	ids := NewDefaultIdentityServer(d)
-
 	s := NewNonBlockingGRPCServer()
 	s.Start(endpoint, ids, nil, ns, testMode)
 	s.Wait()
@@ -97,20 +96,30 @@ func RunControllerPublishServer(endpoint string, d *CSIDriver, cs csi.Controller
 
 func RunControllerandNodePublishServer(endpoint string, d *CSIDriver, cs csi.ControllerServer, ns csi.NodeServer, testMode bool) {
 	ids := NewDefaultIdentityServer(d)
-
 	s := NewNonBlockingGRPCServer()
 	s.Start(endpoint, ids, cs, ns, testMode)
 	s.Wait()
 }
 
+func getLogLevel(method string) int32 {
+	if method == "/csi.v1.Identity/Probe" ||
+		method == "/csi.v1.Node/NodeGetCapabilities" ||
+		method == "/csi.v1.Node/NodeGetVolumeStats" {
+		return 10
+	}
+	return 2
+}
+
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	klog.V(3).Infof("GRPC call: %s", info.FullMethod)
-	klog.V(5).Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
+	level := klog.Level(getLogLevel(info.FullMethod))
+	klog.V(level).Infof("GRPC call: %s", info.FullMethod)
+	klog.V(level).Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
+
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
 	} else {
-		klog.V(5).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+		klog.V(level).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
 	}
 	return resp, err
 }

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -197,3 +197,38 @@ func TestNewNodeServiceCapability(t *testing.T) {
 		assert.Equal(t, resp.XXX_sizecache, int32(0))
 	}
 }
+
+func TestGetLogLevel(t *testing.T) {
+	tests := []struct {
+		method string
+		level  int32
+	}{
+		{
+			method: "/csi.v1.Identity/Probe",
+			level:  10,
+		},
+		{
+			method: "/csi.v1.Node/NodeGetCapabilities",
+			level:  10,
+		},
+		{
+			method: "/csi.v1.Node/NodeGetVolumeStats",
+			level:  10,
+		},
+		{
+			method: "",
+			level:  2,
+		},
+		{
+			method: "unknown",
+			level:  2,
+		},
+	}
+
+	for _, test := range tests {
+		level := getLogLevel(test.method)
+		if level != test.level {
+			t.Errorf("returned level: (%v), expected level: (%v)", level, test.level)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: reduce driver logs

 - don't print follow method logs by default
following 3 method logs constitute 99.8% logs of all driver logs, this PR set the log level of following 3 methods as `10`, and it would not show in driver logs by default(<= `5` will show in driver logs)
```
/csi.v1.Identity/Probe
/csi.v1.Node/NodeGetCapabilities
/csi.v1.Node/NodeGetVolumeStats
```

 - set log level of csi side car contains as 2
This could reduce `17,280` logs every day of csi-provisioner, csi-resizer, etc which has lease election, following logs would show every 5s:
```
I0119 12:57:02.073355       1 leaderelection.go:282] successfully renewed lease kube-system/blob-csi-azure-com
I0119 12:57:07.081182       1 leaderelection.go:282] successfully renewed lease kube-system/blob-csi-azure-com
I0119 12:57:12.097738       1 leaderelection.go:282] successfully renewed lease kube-system/blob-csi-azure-com
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: reduce some method logs
```
