### PR TITLE
cleanup un-used to make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,19 +181,3 @@ install-blobfuse-proxy:
 .PHONY: uninstall-blobfuse-proxy
 uninstall-blobfuse-proxy:
 	kubectl delete -f ./deploy/blobfuse-proxy/blobfuse-proxy.yaml --ignore-not-found
-
-.PHONY: setup-external-e2e
-setup-external-e2e:
-	curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.19.0/kubernetes-test-linux-amd64.tar.gz --output e2e-tests.tar.gz
-	tar -xvf e2e-tests.tar.gz
-	rm e2e-tests.tar.gz
-	mkdir /tmp/csi-blobfuse
-	cp ./kubernetes/test/bin/e2e.test /tmp/csi-blobfuse/e2e.test
-	rm -r kubernetes
-	cp ./deploy/example/storageclass-blobfuse.yaml /tmp/csi-blobfuse/storageclass.yaml
-	cp ./test/e2e-external/testdriver.yaml /tmp/csi-blobfuse/testdriver.yaml
-	./deploy/install-driver.sh
-
-.PHONY: run-external-e2e
-run-external-e2e: setup-external-e2e install-blobfuse-proxy
-	bash ./test/e2e-external/run.sh


### PR DESCRIPTION
the below make targets that were added in https://github.com/kubernetes-sigs/blob-csi-driver/pull/395 were not properly cleaned up. So creating a new PR to cleanup those un-used make targets

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
