### PR TITLE
test: add nfs e2e test

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -106,6 +106,8 @@ type Driver struct {
 	// A map storing all volumes with ongoing operations so that additional operations
 	// for that same volume (as defined by VolumeID) return an Aborted error
 	volumeLocks *volumeLocks
+	// only for nfs feature
+	subnetLockMap *util.LockMap
 }
 
 // NewDriver Creates a NewCSIDriver object. Assumes vendor version is equal to driver version &
@@ -116,6 +118,7 @@ func NewDriver(nodeID, blobfuseProxyEndpoint string, enableBlobfuseProxy bool, b
 	driver.Version = driverVersion
 	driver.NodeID = nodeID
 	driver.volLockMap = util.NewLockMap()
+	driver.subnetLockMap = util.NewLockMap()
 	driver.volumeLocks = newVolumeLocks()
 	driver.blobfuseProxyEndpoint = blobfuseProxyEndpoint
 	driver.enableBlobfuseProxy = enableBlobfuseProxy

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"sigs.k8s.io/blob-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azureclients/storageaccountclient/mockstorageaccountclient"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	"sigs.k8s.io/cloud-provider-azure/pkg/retry"
@@ -47,6 +48,7 @@ func NewFakeDriver() *Driver {
 	driver := NewDriver(fakeNodeID, "", false, 5, false)
 	driver.Name = fakeDriverName
 	driver.Version = vendorVersion
+	driver.subnetLockMap = util.NewLockMap()
 	return driver
 }
 

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -123,6 +123,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		vnetResourceID := d.getSubnetResourceID()
 		klog.V(2).Infof("set vnetResourceID(%s) for NFS protocol", vnetResourceID)
 		vnetResourceIDs = []string{vnetResourceID}
+		if err := d.updateSubnetServiceEndpoints(ctx); err != nil {
+			return nil, status.Errorf(codes.Internal, "update service endpoints failed with error: %v", err)
+		}
 		// NFS protocol does not need account key
 		storeAccountKey = storeAccountKeyFalse
 	}

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -278,6 +278,9 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 	})
 
 	ginkgo.It("should create a NFSv3 volume on demand with mount options [nfs]", func() {
+		if isAzureStackCloud {
+			ginkgo.Skip("test case is not available for Azure Stack")
+		}
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 	})
 
 	testDriver = driver.InitBlobCSIDriver()
-	ginkgo.It("should create a volume on demand", func() {
+	ginkgo.It("should create a volume on demand with mount options", func() {
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
@@ -277,6 +277,35 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		test.Run(cs, ns)
 	})
 
+	ginkgo.It("should create a NFSv3 volume on demand with mount options [nfs]", func() {
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"nconnect=16",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: testDriver,
+			Pods:      pods,
+			StorageClassParameters: map[string]string{
+				"skuName":  "Premium_LRS",
+				"protocol": "nfs",
+			},
+		}
+		test.Run(cs, ns)
+	})
+
 	ginkgo.It("should create a volume on demand (Bring Your Own Key)", func() {
 		// get storage account secret name
 		err := os.Chdir("../..")
@@ -325,7 +354,7 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		test.Run(cs, ns)
 	})
 
-	ginkgo.It("should create a volume on demand and resize it [kubernetes.io/blob-csi] [blob.csi.azure.com]", func() {
+	ginkgo.It("should create a volume on demand and resize it [blob.csi.azure.com]", func() {
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/utils/blob_log.sh
+++ b/test/utils/blob_log.sh
@@ -28,7 +28,7 @@ kubectl get pods -n default -o wide
 echo "======================================================================================"
 
 echo "print out all $NS namespace pods status ..."
-kubectl get pods -n${NS}
+kubectl get pods -n${NS} -o wide
 echo "======================================================================================"
 
 echo "print out csi-blob-controller logs ..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
test: add nfs e2e test and also fixed the nfs account dynamic provisioning issue

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
```
Event initiated by
26f7000f-1d82-44fa-8a55-69c4d5cb1dac
Error code
SubnetsHaveNoServiceEndpointsConfigured
Message
Subnets k8s-subnet of virtual network /subscriptions/xxx/resourceGroups/kubetest-ar68giws/providers/Microsoft.Network/virtualNetworks/k8s-vnet-36253727 do not have ServiceEndpoints for Microsoft.Storage resources configured. Add Microsoft.Storage to subnet's ServiceEndpoints collection before trying to ACL Microsoft.Storage resources to these subnets.
```
 - `SubnetsClient.CreateOrUpdate` takes 5min14s sometimes, and cause test case fail:
```
[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:09:01.659094       1 utils.go:114] GRPC call: /csi.v1.Controller/CreateVolume
[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:09:01.659204       1 utils.go:115] GRPC request: {"capacity_range":{"required_bytes":10737418240},"name":"pvc-27b0405e-a1b3-49ad-ab0a-955635e10391","parameters":{"protocol":"nfs","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["nconnect=16"]}},"access_mode":{"mode":5}}]}
[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:09:01.659776       1 controllerserver.go:124] set vnetResourceID(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-evpuhkod/providers/Microsoft.Network/virtualNetworks/k8s-vnet-38454198/subnets/k8s-subnet) for NFS protocol

[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:12:08.669528       1 utils.go:115] GRPC request: {"capacity_range":{"required_bytes":10737418240},"name":"pvc-27b0405e-a1b3-49ad-ab0a-955635e10391","parameters":{"protocol":"nfs","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["nconnect=16"]}},"access_mode":{"mode":5}}]}
[pod/csi-blob-controller-794746f9dc-c6glr/blob] E0515 14:12:08.669835       1 utils.go:119] GRPC error: rpc error: code = Aborted desc = An operation with the given Volume ID pvc-27b0405e-a1b3-49ad-ab0a-955635e10391 already exists

[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:14:15.163300       1 azure.go:219] serviceEndpoint(Microsoft.Storage) is appended in subnet(k8s-subnet)
[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:14:15.220748       1 azure_storageaccount.go:193] subnetID(/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-evpuhkod/providers/Microsoft.Network/virtualNetworks/k8s-vnet-38454198/subnets/k8s-subnet) has been set
[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:14:15.220772       1 azure_storageaccount.go:222] azure - no matching account found, begin to create a new account nfs36b29a9dab64445eb01e in resource group kubetest-evpuhkod, location: westus2, accountType: Premium_LRS, accountKind: BlockBlobStorage, tags: map[created-by:azure]

[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:14:43.986418       1 controllerserver.go:200] begin to create container(pvc-27b0405e-a1b3-49ad-ab0a-955635e10391) on account(nfs36b29a9dab64445eb01e) type(Premium_LRS) rg(kubetest-evpuhkod) location() size(10)
[pod/csi-blob-controller-794746f9dc-c6glr/blob] I0515 14:14:44.226342       1 controllerserver.go:228] create container pvc-27b0405e-a1b3-49ad-ab0a-955635e10391 on storage account nfs36b29a9dab64445eb01e successfully
```

**Release note**:
```
none
```
