### PR TITLE
Added log for multiple pods command, fexed markup

### DIFF
--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -2,14 +2,16 @@
 ### Case#1: volume create/delete issue
  - locate csi driver pod
 ```console
-$ kubectl get po -o wide -n kube-system | grep csi-blob-controller
+kubectl get po -o wide -n kube-system | grep csi-blob-controller
+```
+<pre>
 NAME                                       READY   STATUS    RESTARTS   AGE     IP             NODE
 csi-blob-controller-56bfddd689-dh5tk       4/4     Running   0          35s     10.240.0.19    k8s-agentpool-22533604-0
 csi-blob-controller-56bfddd689-sl4ll       4/4     Running   0          35s     10.240.0.23    k8s-agentpool-22533604-1
-```
+</pre>
  - get csi driver logs
 ```console
-$ kubectl logs csi-blob-controller-56bfddd689-dh5tk -c blob -n kube-system > csi-blob-controller.log
+kubectl logs csi-blob-controller-56bfddd689-dh5tk -c blob -n kube-system > csi-blob-controller.log
 ```
 > note: there could be multiple controller pods, logs can be taken from all of them simultaneously, also with `follow` (realtime) mode
 > `kubectl logs deploy/csi-blob-controller -c blob -f -n kube-system`
@@ -17,27 +19,35 @@ $ kubectl logs csi-blob-controller-56bfddd689-dh5tk -c blob -n kube-system > csi
 ### Case#2: volume mount/unmount failed
  - locate csi driver pod and make sure which pod do tha actual volume mount/unmount
 ```console
-$ kubectl get po -o wide -n kube-system | grep csi-blob-node
+kubectl get po -o wide -n kube-system | grep csi-blob-node
+```
+<pre>
 NAME                                       READY   STATUS    RESTARTS   AGE     IP             NODE
 csi-blob-node-cvgbs                        3/3     Running   0          7m4s    10.240.0.35    k8s-agentpool-22533604-1
 csi-blob-node-dr4s4                        3/3     Running   0          7m4s    10.240.0.4     k8s-agentpool-22533604-0
-```
+</pre>
 
  - get csi driver logs
 ```console
-$ kubectl logs csi-blob-node-cvgbs -c blob -n kube-system > csi-blob-node.log
+kubectl logs csi-blob-node-cvgbs -c blob -n kube-system > csi-blob-node.log
 ```
+> note: to watch logs in realtime from multiple `csi-blob-node` DaemonSet pods simultaneously, run the command:
+> ```console
+> kubectl logs daemonset/csi-blob-node -c blob -n kube-system -f
+> ```
 
 ### get blobfuse driver version
 ```console
-# kubectl exec -it csi-blob-node-fmbqw -n kube-system -c blob -- sh
-# blobfuse -v
-blobfuse 1.2.4
+kubectl exec -it csi-blob-node-fmbqw -n kube-system -c blob -- sh
+blobfuse -v
 ```
+<pre>
+blobfuse 1.2.4
+</pre>
 
 ### check blobfuse mount on the agent node
 ```console
-# mount | grep blobfuse | uniq
+mount | grep blobfuse | uniq
 ```
 
 ### troubleshooting connection failure on agent node


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Cleanup of README

Fixes #
* Added logs comand for multiple pods of daemonset
* Markup with _'''console_ adds "copy" icon - including console output to this block ruins this feature
![image](https://user-images.githubusercontent.com/702860/118597306-d0300d00-b7ac-11eb-8ca0-87fc85736c92.png)
