### PR TITLE
fix: only use pod.Namespace in inline volume support

### DIFF
--- a/deploy/example/nginx-blobfuse-inline-volume.yaml
+++ b/deploy/example/nginx-blobfuse-inline-volume.yaml
@@ -23,4 +23,3 @@ spec:
         volumeAttributes:
           containerName: EXISTING_CONTAINER_NAME
           secretName: azure-secret
-          secretNamespace: default  # optional, if it's empty, use pod.Namespace by default

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -70,15 +70,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	context := req.GetVolumeContext()
 	if context != nil && context["csi.storage.k8s.io/ephemeral"] == "true" {
-		// if secretNamespace is not set, set same namespace as pod
-		secretNamespace := context["csi.storage.k8s.io/pod.namespace"]
-		for k, v := range context {
-			switch strings.ToLower(k) {
-			case secretNamespaceField:
-				secretNamespace = v
-			}
-		}
-		context[secretNamespaceField] = secretNamespace
+		context[secretNamespaceField] = context["csi.storage.k8s.io/pod.namespace"]
 		klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s, VolumeContext: %v", volumeID, target, context)
 		_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 			StagingTargetPath: target,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: only use pod.Namespace in inline volume support

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
