### PR TITLE
fix: CVE issues in image build

### DIFF
--- a/pkg/blobplugin/Dockerfile
+++ b/pkg/blobplugin/Dockerfile
@@ -21,7 +21,7 @@ COPY ${binary} /blobplugin
 RUN apt update && apt-mark unhold libcap2
 RUN clean-install ca-certificates uuid-dev util-linux mount udev wget e2fsprogs nfs-common netbase
 # install updated packages to fix CVE issues
-RUN clean-install libgmp10 bsdutils libssl1.1 openssl
+RUN clean-install libgmp10 bsdutils libssl1.1 openssl libc-bin libsystemd0
 RUN mkdir /blobfuse-proxy/
 COPY ./_output/blobfuse-proxy.deb /blobfuse-proxy/
 ARG ARCH=amd64

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -139,19 +139,13 @@ var _ = ginkgo.AfterSuite(func() {
 		startLog: "===================blob log===================",
 		endLog:   "==================================================",
 	}
-	deleteMetricsSVC := testCmd{
-		command:  "make",
-		args:     []string{"delete-metrics-svc"},
-		startLog: "delete metrics service...",
-		endLog:   "metrics service deleted",
-	}
 	e2eTeardown := testCmd{
 		command:  "make",
 		args:     []string{"e2e-teardown"},
 		startLog: "Uninstalling Azure Blob Storage CSI driver...",
 		endLog:   "Azure Blob Storage CSI driver uninstalled",
 	}
-	execTestCmd([]testCmd{blobLog, deleteMetricsSVC, e2eTeardown})
+	execTestCmd([]testCmd{blobLog, e2eTeardown})
 
 	// install/uninstall CSI Driver deployment scripts test
 	installDriver := testCmd{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: CVE issues in image build

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

```
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
|   LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libc-bin    | CVE-2021-33574   | CRITICAL | 2.[31](https://github.com/kubernetes-sigs/blob-csi-driver/runs/5706823026?check_suite_focus=true#step:6:31)-13+deb11u2   | 2.31-13+deb11u3 | glibc: mq_notify does                 |
|             |                  |          |                   |                 | not handle separately                 |
|             |                  |          |                   |                 | allocated thread attributes           |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-33574 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-2[32](https://github.com/kubernetes-sigs/blob-csi-driver/runs/5706823026?check_suite_focus=true#step:6:32)18   |          |                   |                 | glibc: Stack-based buffer overflow    |
|             |                  |          |                   |                 | in svcunix_create via long pathnames  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23218 |
+             +------------------+          +                   +                 +---------------------------------------+
|             | CVE-2022-23219   |          |                   |                 | glibc: Stack-based buffer             |
|             |                  |          |                   |                 | overflow in sunrpc clnt_create        |
|             |                  |          |                   |                 | via a long pathname                   |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2022-23219 |
+             +------------------+----------+                   +                 +---------------------------------------+
|             | CVE-2021-4[33](https://github.com/kubernetes-sigs/blob-csi-driver/runs/5706823026?check_suite_focus=true#step:6:33)96   | LOW      |                   |                 | glibc: conversion from                |
|             |                  |          |                   |                 | ISO-2022-JP-3 with iconv may          |
|             |                  |          |                   |                 | emit spurious NUL character on...     |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-43[39](https://github.com/kubernetes-sigs/blob-csi-driver/runs/5706823026?check_suite_focus=true#step:6:39)6 |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libsystemd0 | CVE-2021-3997    | MEDIUM   | 2[47](https://github.com/kubernetes-sigs/blob-csi-driver/runs/5706823026?check_suite_focus=true#step:6:47).3-6           | 247.3-7         | systemd: Uncontrolled recursion in    |
|             |                  |          |                   |                 | systemd-tmpfiles when removing files  |
|             |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-3997  |
+-------------+------------------+----------+-------------------+-----------------+---------------------------------------+
```

**Release note**:
```
fix: CVE issues in image build
```

