### PR TITLE
[WIP]feat: support private end point in dynamic provisioning

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -27,6 +27,7 @@ secretName | specify secret name to store account key | | No |
 secretNamespace | specify the namespace of secret to store account key | `default`,`kube-system`, etc | No | pvc namespace
 isHnsEnabled | enable `Hierarchical namespace` for Azure DataLake storage account | `true`,`false` | No | `false`
 --- | **Following parameters are only for NFS protocol** | --- | --- |
+networkEndpointType | specify network endpoint type for the storage account created by driver. If `privateEndpoint` is specified, a private endpoint will be created for the storage account. For other cases, a service endpoint will be created by default. | "",`privateEndpoint` | No | ``
 mountPermissions | mounted folder permissions | `0777` | No |
 
  - `fsGroup` securityContext setting

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -74,6 +74,7 @@ const (
 	keyVaultSecretVersionField   = "keyvaultsecretversion"
 	storageAccountNameField      = "storageaccountname"
 	allowBlobPublicAccessField   = "allowblobpublicaccess"
+	networkEndpointTypeField     = "networkendpointtype"
 	ephemeralField               = "csi.storage.k8s.io/ephemeral"
 	podNamespaceField            = "csi.storage.k8s.io/pod.namespace"
 	mountOptionsField            = "mountoptions"
@@ -109,6 +110,9 @@ const (
 	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
+
+	privateEndpoint              = "privateendpoint"
+	defaultStorageEndPointSuffix = "core.windows.net"
 )
 
 var (

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -531,4 +531,38 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		}
 		test.Run(cs, ns)
 	})
+
+	ginkgo.It("should create a NFSv3 volume using private end point [nfs]", func() {
+		if isAzureStackCloud {
+			ginkgo.Skip("test case is not available for Azure Stack")
+		}
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"nconnect=8",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: testDriver,
+			Pods:      pods,
+			StorageClassParameters: map[string]string{
+				"skuName":             "Premium_LRS",
+				"protocol":            "nfs",
+				"networkEndpointType": "privateEndpoint",
+				"mountPermissions":    "0755",
+			},
+		}
+		test.Run(cs, ns)
+	})
 })

--- a/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_storageaccount.go
+++ b/vendor/sigs.k8s.io/cloud-provider-azure/pkg/provider/azure_storageaccount.go
@@ -36,7 +36,7 @@ import (
 // SkipMatchingTag skip account matching tag
 const SkipMatchingTag = "skip-matching"
 const LocationGlobal = "global"
-const GroupIDFile = "file"
+const GroupIDFile = "blob"
 const PrivateDNSZoneName = "privatelink.file.core.windows.net"
 
 // AccountOptions contains the fields which are used to create storage account.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support private end point in dynamic provisioning

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

failed with 
```
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:20:17.775603       1 utils.go:75] GRPC call: /csi.v1.Controller/CreateVolume
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:20:17.775626       1 utils.go:76] GRPC request: {"capacity_range":{"required_bytes":10737418240},"name":"pvc-52ba8e85-acfe-4484-837e-7368d162e46b","parameters":{"csi.storage.k8s.io/pv/name":"pvc-52ba8e85-acfe-4484-837e-7368d162e46b","csi.storage.k8s.io/pvc/name":"pvc-cp7ds","csi.storage.k8s.io/pvc/namespace":"blob-4376","mountPermissions":"0755","networkEndpointType":"privateEndpoint","protocol":"nfs","skuName":"Premium_LRS"},"volume_capabilities":[{"AccessType":{"Mount":{"mount_flags":["nconnect=8"]}},"access_mode":{"mode":5}}]}
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:20:17.835487       1 azure_storageaccount.go:360] Creating private dns zone(privatelink.file.core.windows.net) in resourceGroup (kubetest-kk9bwedw)
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:20:48.956745       1 azure_storageaccount.go:246] azure - no matching account found, begin to create a new account nfs70da8f3ec32d47f6a349 in resource group kubetest-kk9bwedw, location: eastus2, accountType: Premium_LRS, accountKind: BlockBlobStorage, tags: map[k8s-azure-created-by:azure]
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:20:48.956821       1 azure_storageaccount.go:267] set AllowBlobPublicAccess(false) for storage account(nfs70da8f3ec32d47f6a349)
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:21:11.002787       1 azure_storageaccount.go:330] Creating private endpoint(nfs70da8f3ec32d47f6a349-pvtendpoint) for account (nfs70da8f3ec32d47f6a349)
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:21:55.018255       1 azure_storageaccount.go:374] Creating virtual link for vnet(nfs70da8f3ec32d47f6a349-vnetlink) and DNS Zone(privatelink.file.core.windows.net) in resourceGroup(kubetest-kk9bwedw)
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:21:55.876560       1 azure_storageaccount.go:387] Creating private DNS zone group(nfs70da8f3ec32d47f6a349-dnszonegroup) with privateEndpoint(nfs70da8f3ec32d47f6a349-pvtendpoint), vNetName(k8s-vnet-12935061), resourceGroup(kubetest-kk9bwedw)
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:21:56.218774       1 controllerserver.go:325] begin to create container(pvc-52ba8e85-acfe-4484-837e-7368d162e46b) on account(nfs70da8f3ec32d47f6a349) type(Premium_LRS) rg(kubetest-kk9bwedw) location() size(10)
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] I0418 11:21:56.255723       1 azure_metrics.go:112] "Observed Request Latency" latency_seconds=0.036913752 request="blob_csi_driver_controller_create_volume" resource_group="kubetest-kk9bwedw" subscription_id="0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e" source="blob.csi.azure.com" ="" result_code="failed"
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] E0418 11:21:56.255768       1 utils.go:80] GRPC error: failed to create container(pvc-52ba8e85-acfe-4484-837e-7368d162e46b) on account(nfs70da8f3ec32d47f6a349) type(Premium_LRS) rg(kubetest-kk9bwedw) location() size(10), error: storage: service returned error: StatusCode=403, ErrorCode=AuthorizationFailure, ErrorMessage=This request is not authorized to perform this operation.
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] RequestId:e287a605-801e-00e7-4616-53e247000000
[pod/csi-blob-controller-6db64b56dc-2fjth/blob] Time:2022-04-18T11:21:56.2549464Z, RequestInitiated=Mon, 18 Apr 2022 11:21:55 GMT, RequestId=e287a605-801e-00e7-4616-53e247000000, API Version=, QueryParameterName=, QueryParameterValue=
```

**Release note**:
```
feat: support private end point in dynamic provisioning
```
