### PR TITLE
test: fix TestLogGRPC ut failure

### DIFF
--- a/pkg/csi-common/server_test.go
+++ b/pkg/csi-common/server_test.go
@@ -19,6 +19,7 @@ package csicommon
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -31,7 +32,10 @@ func TestNewNonBlockingGRPCServer(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	s := NewNonBlockingGRPCServer()
+	// sleep a while to avoid race condition in unit test
+	time.Sleep(time.Millisecond * 500)
 	s.Start("tcp://127.0.0.1:0", nil, nil, nil, true)
+	time.Sleep(time.Millisecond * 500)
 }
 
 func TestServe(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind test

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

fix TestLogGRPC ut failure

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

this PR tries to fix the following issue:
```=== RUN   TestLogGRPC
==================
WARNING: DATA RACE
Write at 0x000001d620e0 by goroutine 25:
  flag.newBoolValue()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:128 +0x208
  flag.(*FlagSet).BoolVar()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:715 +0x214
  k8s.io/klog/v2.InitFlags()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:429 +0x1e6
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestLogGRPC()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/utils_test.go:87 +0x44
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:[1446](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/7762127363?check_suite_focus=true#step:5:1447) +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47

Previous read at 0x000001d620e0 by goroutine 16:
  k8s.io/klog/v2.(*loggingT).output()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:879 +0x375
  k8s.io/klog/v2.(*loggingT).printfDepth()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:737 +0x2f7
  k8s.io/klog/v2.(*loggingT).printf()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:719 +0x98b
  k8s.io/klog/v2.Infof()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:[1465](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/7762127363?check_suite_focus=true#step:5:1466) +0x910
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).serve()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:117 +0x85a
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start.func1()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0xec

Goroutine 25 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:[1493](https://github.com/kubernetes-sigs/azuredisk-csi-driver/runs/7762127363?check_suite_focus=true#step:5:1494) +0x75d
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:79 +0x2e9

Goroutine 16 (finished) created at:
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0x206
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestStart()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server_test.go:37 +0xae
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x000001d6219a by goroutine 25:
  flag.newBoolValue()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:128 +0x2fb
  flag.(*FlagSet).BoolVar()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/flag/flag.go:715 +0x307
  k8s.io/klog/v2.InitFlags()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:432 +0x2d6
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestLogGRPC()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/utils_test.go:87 +0x44
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47

Previous read at 0x000001d6219a by goroutine 16:
  k8s.io/klog/v2.(*loggingT).header()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:656 +0xc8
  k8s.io/klog/v2.(*loggingT).printfDepth()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:723 +0x87
  k8s.io/klog/v2.(*loggingT).printf()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:719 +0x98b
  k8s.io/klog/v2.Infof()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/vendor/k8s.io/klog/v2/klog.go:1465 +0x910
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).serve()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:117 +0x85a
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start.func1()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0xec

Goroutine 25 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:79 +0x2e9

Goroutine 16 (finished) created at:
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.(*nonBlockingGRPCServer).Start()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server.go:56 +0x206
  sigs.k8s.io/azuredisk-csi-driver/pkg/csi-common.TestStart()
      /Users/runner/work/azuredisk-csi-driver/azuredisk-csi-driver/pkg/csi-common/server_test.go:37 +0xae
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /Users/runner/hostedtoolcache/go/1.19.0/x64/src/testing/testing.go:1493 +0x47```

**Release note**:
```
none
```
