### PR TITLE
fix race in unit test and add some simple tests for utils

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -170,3 +170,47 @@ func TestMakeDir(t *testing.T) {
 	err = os.RemoveAll(targetTest)
 	assert.NoError(t, err)
 }
+
+func TestConvertTagsToMap(t *testing.T) {
+	type StringMap map[string]string
+	tests := []struct {
+		tags     string
+		expected map[string]string
+		err      bool
+	}{
+		{
+			tags:     "",
+			expected: StringMap{},
+			err:      false,
+		},
+		{
+			tags:     "key1=value1, key2=value2,key3= value3",
+			expected: StringMap{"key1": "value1", "key2": "value2", "key3": "value3"},
+			err:      false,
+		},
+		{
+			tags:     " key = value ",
+			expected: StringMap{"key": "value"},
+			err:      false,
+		},
+		{
+			tags:     "keyvalue",
+			expected: nil,
+			err:      true,
+		},
+		{
+			tags:     " = value,=",
+			expected: nil,
+			err:      true,
+		},
+	}
+	for _, test := range tests {
+		result, err := ConvertTagsToMap(test.tags)
+		if test.err {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, result, test.expected)
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -146,6 +146,10 @@ func TestGetMountOptions(t *testing.T) {
 			options:  []string{""},
 			expected: "",
 		},
+		{
+			options:  []string{},
+			expected: "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Add some coverage to `pkg/util` tests.

Fix a race in csi-common test, described in commit text:
```
    Without this fix, running `go test -race -count 10` causes this failure:

    /var/folders/py/rwp4m4k977l9stj_f2kqrmxw000_5c/T/go-build3764188957/b001/csi-common.test flag redefined: log_dir
    --- FAIL: TestLogGRPC (0.00s)
    panic: /var/folders/py/rwp4m4k977l9stj_f2kqrmxw000_5c/T/go-build3764188957/b001/csi-common.test flag redefined: log_dir [recovered]
            panic: /var/folders/py/rwp4m4k977l9stj_f2kqrmxw000_5c/T/go-build3764188957/b001/csi-common.test flag redefined: log_dir

    goroutine 70 [running]:
    testing.tRunner.func1.2({0x17a37e0, 0xc0000b4180})
            /usr/local/Cellar/go/1.18.5/libexec/src/testing/testing.go:1389 +0x366
    testing.tRunner.func1()
            /usr/local/Cellar/go/1.18.5/libexec/src/testing/testing.go:1392 +0x5d2
    panic({0x17a37e0, 0xc0000b4180})
            /usr/local/Cellar/go/1.18.5/libexec/src/runtime/panic.go:844 +0x258
    flag.(*FlagSet).Var(0xc00020c120, {0x19668c0, 0x1d00f90}, {0x186cfd4, 0x7}, {0x188d879, 0x52})
            /usr/local/Cellar/go/1.18.5/libexec/src/flag/flag.go:879 +0x3a5
    flag.(*FlagSet).StringVar(...)
            /usr/local/Cellar/go/1.18.5/libexec/src/flag/flag.go:762
    k8s.io/klog/v2.InitFlags(0x0)
            /Users/avoltz/src/blob-csi-driver/vendor/k8s.io/klog/v2/klog.go:424 +0xee
    sigs.k8s.io/blob-csi-driver/pkg/csi-common.TestLogGRPC(0xc0000829c0)
            /Users/avoltz/src/blob-csi-driver/pkg/csi-common/utils_test.go:87 +0x45
    testing.tRunner(0xc0000829c0, 0x18ae070)
            /usr/local/Cellar/go/1.18.5/libexec/src/testing/testing.go:1439 +0x214
    created by testing.(*T).Run
            /usr/local/Cellar/go/1.18.5/libexec/src/testing/testing.go:1486 +0x725
    FAIL    sigs.k8s.io/blob-csi-driver/pkg/csi-common      4.298s
    FAIL
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
