### PR TITLE
fix: add workaround for blobfuse2 mount race condition issue

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -181,7 +181,11 @@ func (d *Driver) mountBlobfuseInsideDriver(args string, protocol string, authEnv
 	cmd.Env = append(os.Environ(), authEnv...)
 	output, err := cmd.CombinedOutput()
 	klog.V(2).Infof("mount output: %s\n", string(output))
-
+	if err == nil && protocol == Fuse2 {
+		// todo: remove this when https://github.com/Azure/azure-storage-fuse/issues/1079 is fixed
+		klog.V(2).Infof("sleep 2s, waiting for blobfuse2 mount complete")
+		time.Sleep(2 * time.Second)
+	}
 	return string(output), err
 }
 

--- a/pkg/blobfuse-proxy/server/server.go
+++ b/pkg/blobfuse-proxy/server/server.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
@@ -94,6 +95,11 @@ func (server *MountServer) MountAzureBlob(ctx context.Context,
 	klog.V(2).Infof("blobfuse output: %s\n", result.Output)
 	if err != nil {
 		return &result, fmt.Errorf("%w %s", err, result.Output)
+	}
+	if protocol == blob.Fuse2 || server.blobfuseVersion == BlobfuseV2 {
+		// todo: remove this when https://github.com/Azure/azure-storage-fuse/issues/1079 is fixed
+		klog.V(2).Infof("sleep 2s, waiting for blobfuse2 mount complete\n")
+		time.Sleep(2 * time.Second)
 	}
 	return &result, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: add workaround for blobfuse2 mount issue
unlike blobfusev1, blobfuse2 would create a new child process to handle mount, thuse blobfuse mount becomes async now, there would be race condition between real mount process and next bind mount operation if it's async mount, 
this PR would sleep 2s waiting for mount process complete
details: https://github.com/Azure/azure-storage-fuse/issues/1079

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
also verified manually, after sleep 2s, there is no more mount on local disk any more:
```
# mount | grep blobfuse2
blobfuse2 on /var/lib/kubelet/plugins/kubernetes.io/csi/blob.csi.azure.com/1f778bb6414796cfefe77ad67ee6e5f21be127ed1adf86affb766488a15ebee4/globalmount type fuse (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
blobfuse2 on /var/lib/kubelet/pods/5a555547-46b4-45f3-8da6-4896903a8dd3/volumes/kubernetes.io~csi/pvc-32e09edb-ac53-4240-976a-6e810e270018/mount type fuse (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
root@aks-agentpool-20541019-vmss000000:/# mount | grep sda
/dev/sda1 on / type ext4 (rw,relatime,discard)
/dev/sda15 on /boot/efi type vfat (rw,relatime,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
/dev/sda1 on /var/lib/kubelet type ext4 (rw,relatime,discard)
```

**Release note**:
```
fix: add workaround for blobfuse2 mount race condition issue
```
