### PR TITLE
fix: nfs volume creation failure due to Microsoft.Storage.Global Service endpoint enabled

### DIFF
--- a/pkg/blob/azure.go
+++ b/pkg/blob/azure.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	providerconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
@@ -240,7 +241,7 @@ func (d *Driver) updateSubnetServiceEndpoints(ctx context.Context, vnetResourceG
 	}
 	serviceEndpoints := *subnet.SubnetPropertiesFormat.ServiceEndpoints
 	for _, v := range serviceEndpoints {
-		if v.Service != nil && *v.Service == storageService {
+		if strings.HasPrefix(pointer.StringDeref(v.Service, ""), storageService) {
 			storageServiceExists = true
 			klog.V(4).Infof("serviceEndpoint(%s) is already in subnet(%s)", storageService, subnetName)
 			break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: nfs volume creation failure due to Microsoft.Storage.Global Service endpoint enabled

 - error msg
```
35s         Warning   ProvisioningFailed      persistentvolumeclaim/pvc-azurefile   failed to provision volume with StorageClass "azurefile-nfs": rpc error: code = Internal desc = update service endpoints failed with error: failed to update the subnet aks-subnet under vnet aks-vnet-32454943: &{false 400 0001-01-01 00:00:00 +0000 UTC {
  "error": {
    "code": "SubnetHasBothRegionalAndGlobalStorageServiceEndpointsTogether",
    "message": "Subnet /subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Network/virtualNetworks/aks-vnet-32454943/subnets/aks-subnet has ServiceEndpoint entries for both 'Microsoft.Storage' and 'Microsoft.Storage.Global' together. Please use either one of them at a time.",
    "details": []
  }
}}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
fix: nfs volume creation failure due to Microsoft.Storage.Global Service endpoint enabled
```
