### PR TITLE
feat: add allowSharedKeyAccess parameter

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -46,6 +46,7 @@ containerNamePrefix | specify Azure storage directory prefix created by driver |
 server | specify Azure storage account server address | existing server address, e.g. `accountname.privatelink.blob.core.windows.net` | No | if empty, driver will use default `accountname.blob.core.windows.net` or other sovereign cloud account address
 accessTier | [Access tier for storage account](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview) | Standard account can choose `Hot` or `Cool`, and Premium account can only choose `Premium` | No | empty(use default setting for different storage account types)
 allowBlobPublicAccess | Allow or disallow public access to all blobs or containers for storage account created by driver | `true`,`false` | No | `false`
+allowSharedKeyAccess | Allow or disallow shared key access for storage account created by driver | `true`,`false` | No | `true`
 requireInfraEncryption | specify whether or not the service applies a secondary layer of encryption with platform managed keys for data at rest for storage account created by driver | `true`,`false` | No | `false`
 storageEndpointSuffix | specify Azure storage endpoint suffix | `core.windows.net`, `core.chinacloudapi.cn`, etc | No | if empty, driver will use default storage endpoint suffix according to cloud environment
 tags | [tags](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources) would be created in newly created storage account | tag format: 'foo=aaa,bar=bbb' | No | ""

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -94,6 +94,7 @@ const (
 	keyVaultSecretVersionField     = "keyvaultsecretversion"
 	storageAccountNameField        = "storageaccountname"
 	allowBlobPublicAccessField     = "allowblobpublicaccess"
+	allowSharedKeyAccessField      = "allowsharedkeyaccess"
 	requireInfraEncryptionField    = "requireinfraencryption"
 	ephemeralField                 = "csi.storage.k8s.io/ephemeral"
 	podNamespaceField              = "csi.storage.k8s.io/pod.namespace"

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -105,6 +105,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	var err error
 	// set allowBlobPublicAccess as false by default
 	allowBlobPublicAccess := pointer.Bool(false)
+	// set allowBlobPublicAccess as true by default
+	allowSharedKeyAccess := pointer.Bool(true)
 
 	containerNameReplaceMap := map[string]string{}
 
@@ -170,6 +172,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		case allowBlobPublicAccessField:
 			if strings.EqualFold(v, trueValue) {
 				allowBlobPublicAccess = pointer.Bool(true)
+			}
+		case allowSharedKeyAccessField:
+			if strings.EqualFold(v, falseValue) {
+				allowSharedKeyAccess = pointer.Bool(false)
 			}
 		case requireInfraEncryptionField:
 			if strings.EqualFold(v, trueValue) {
@@ -310,6 +316,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		storageEndpointSuffix = d.getStorageEndPointSuffix()
 	}
 
+	if storeAccountKey && !pointer.BoolDeref(allowSharedKeyAccess, false) {
+		return nil, status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
+	}
+
 	accountOptions := &azure.AccountOptions{
 		Name:                            account,
 		Type:                            storageAccountType,
@@ -324,6 +334,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		IsHnsEnabled:                    isHnsEnabled,
 		EnableNfsV3:                     enableNfsV3,
 		AllowBlobPublicAccess:           allowBlobPublicAccess,
+		AllowSharedKeyAccess:            allowSharedKeyAccess,
 		RequireInfrastructureEncryption: requireInfraEncryption,
 		VNetResourceGroup:               vnetResourceGroup,
 		VNetName:                        vnetName,

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -97,7 +97,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		parameters = make(map[string]string)
 	}
 	var storageAccountType, subsID, resourceGroup, location, account, containerName, containerNamePrefix, protocol, customTags, secretName, secretNamespace, pvcNamespace, tagValueDelimiter string
-	var isHnsEnabled, requireInfraEncryption, enableBlobVersioning, createPrivateEndpoint, enableNfsV3 *bool
+	var isHnsEnabled, requireInfraEncryption, enableBlobVersioning, createPrivateEndpoint, enableNfsV3, allowSharedKeyAccess *bool
 	var vnetResourceGroup, vnetName, subnetName, accessTier, networkEndpointType, storageEndpointSuffix, fsGroupChangePolicy string
 	var matchTags, useDataPlaneAPI, getLatestAccountKey bool
 	var softDeleteBlobs, softDeleteContainers int32
@@ -105,8 +105,6 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	var err error
 	// set allowBlobPublicAccess as false by default
 	allowBlobPublicAccess := pointer.Bool(false)
-	// set allowBlobPublicAccess as true by default
-	allowSharedKeyAccess := pointer.Bool(true)
 
 	containerNameReplaceMap := map[string]string{}
 
@@ -174,9 +172,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				allowBlobPublicAccess = pointer.Bool(true)
 			}
 		case allowSharedKeyAccessField:
-			if strings.EqualFold(v, falseValue) {
-				allowSharedKeyAccess = pointer.Bool(false)
+			var boolValue bool
+			if boolValue, err = strconv.ParseBool(v); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %s in volume context", allowSharedKeyAccessField, v)
 			}
+			allowSharedKeyAccess = pointer.Bool(boolValue)
 		case requireInfraEncryptionField:
 			if strings.EqualFold(v, trueValue) {
 				requireInfraEncryption = pointer.Bool(true)
@@ -316,7 +316,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		storageEndpointSuffix = d.getStorageEndPointSuffix()
 	}
 
-	if storeAccountKey && !pointer.BoolDeref(allowSharedKeyAccess, false) {
+	if storeAccountKey && !pointer.BoolDeref(allowSharedKeyAccess, true) {
 		return nil, status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
 	}
 

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -92,6 +92,40 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
+	ginkgo.It("should create a volume on demand with storage account having shared access key disabled", func(ctx ginkgo.SpecContext) {
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"-o allow_other",
+							"--file-cache-timeout-in-seconds=120",
+							"--cancel-list-on-mount-seconds=0",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: testDriver,
+			Pods:      pods,
+			StorageClassParameters: map[string]string{
+				"skuName":                      "Standard_GRS",
+				"storeAccountKey":              "false",
+				"allowSharedKeyAccess":         "false",
+				"AzureStorageAuthType":         "msi",
+				"AzureStorageIdentityClientID": "dummy",
+			},
+		}
+		test.Run(ctx, cs, ns)
+	})
+
 	ginkgo.It("should create a volume on demand with mount options", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -92,40 +92,6 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
-	ginkgo.It("should create a volume on demand with storage account having shared access key disabled", func(ctx ginkgo.SpecContext) {
-		pods := []testsuites.PodDetails{
-			{
-				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
-				Volumes: []testsuites.VolumeDetails{
-					{
-						ClaimSize: "10Gi",
-						MountOptions: []string{
-							"-o allow_other",
-							"--file-cache-timeout-in-seconds=120",
-							"--cancel-list-on-mount-seconds=0",
-						},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
-			CSIDriver: testDriver,
-			Pods:      pods,
-			StorageClassParameters: map[string]string{
-				"skuName":                      "Standard_GRS",
-				"storeAccountKey":              "false",
-				"allowSharedKeyAccess":         "false",
-				"AzureStorageAuthType":         "msi",
-				"AzureStorageIdentityClientID": "dummy",
-			},
-		}
-		test.Run(ctx, cs, ns)
-	})
-
 	ginkgo.It("should create a volume on demand with mount options", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{
@@ -619,9 +585,10 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
-				"skuName":          "Premium_LRS",
-				"protocol":         "nfs",
-				"mountPermissions": "0",
+				"skuName":              "Premium_LRS",
+				"protocol":             "nfs",
+				"mountPermissions":     "0",
+				"allowSharedKeyAccess": "false",
 			},
 		}
 		test.Run(ctx, cs, ns)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allows to provision dynamic storage accounts with shared key access disabled.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1462.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Tested on AKS cluster by mounting dynamic PVC to a pod and writing a file.
Storage class spec:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: azureblob-fuse
reclaimPolicy: Delete
volumeBindingMode: Immediate
provisioner: blob.csi.azure.com
allowVolumeExpansion: true
parameters:
  skuName: Premium_LRS
  allowSharedKeyAccess: "false"
  storeAccountKey: "false"
  AzureStorageAuthType: msi
  AzureStorageIdentityClientID: <redacted>
```

**Release note**:
```
none
```
