### PR TITLE
fix: clone volume content to requested volume

### DIFF
--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -81,18 +81,11 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	if acquired := d.volumeLocks.TryAcquire(volName); !acquired {
-		// logging the job status if it's volume cloning
-		if req.GetVolumeContentSource() != nil {
-			jobState, percent, err := d.azcopy.GetAzcopyJob(volName, []string{})
-			return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsWithAzcopyFmt, volName, jobState, percent, err)
-		}
-		return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, volName)
-	}
-	defer d.volumeLocks.Release(volName)
-
 	volSizeBytes := int64(req.GetCapacityRange().GetRequiredBytes())
 	requestGiB := int(util.RoundUpGiB(volSizeBytes))
+
+	volContentSource := req.GetVolumeContentSource()
+	secrets := req.GetSecrets()
 
 	parameters := req.GetParameters()
 	if parameters == nil {
@@ -351,10 +344,31 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		GetLatestAccountKey:             getLatestAccountKey,
 	}
 
+	containerName = replaceWithMap(containerName, containerNameReplaceMap)
+	validContainerName := containerName
+	if validContainerName == "" {
+		validContainerName = volName
+		if containerNamePrefix != "" {
+			validContainerName = containerNamePrefix + "-" + volName
+		}
+		validContainerName = getValidContainerName(validContainerName, protocol)
+		setKeyValueInMap(parameters, containerNameField, validContainerName)
+	}
+
+	if acquired := d.volumeLocks.TryAcquire(volName); !acquired {
+		// logging the job status if it's volume cloning
+		if volContentSource != nil {
+			jobState, percent, err := d.azcopy.GetAzcopyJob(validContainerName, []string{})
+			return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsWithAzcopyFmt, volName, jobState, percent, err)
+		}
+		return nil, status.Errorf(codes.Aborted, volumeOperationAlreadyExistsFmt, volName)
+	}
+	defer d.volumeLocks.Release(volName)
+
 	var volumeID string
 	requestName := "controller_create_volume"
-	if req.GetVolumeContentSource() != nil {
-		switch req.VolumeContentSource.Type.(type) {
+	if volContentSource != nil {
+		switch volContentSource.Type.(type) {
 		case *csi.VolumeContentSource_Snapshot:
 			requestName = "controller_create_volume_from_snapshot"
 		case *csi.VolumeContentSource_Volume:
@@ -367,9 +381,39 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		mc.ObserveOperationWithResult(isOperationSucceeded, VolumeID, volumeID)
 	}()
 
+	var srcAzcopyAuthEnv []string
+	var srcSubscriptionID, srcResourceGroupName, srcAccountName, srcContainerName, srcPath, srcAccountSASToken string
+	if volContentSource != nil {
+		switch volContentSource.Type.(type) {
+		case *csi.VolumeContentSource_Snapshot:
+			return nil, status.Errorf(codes.InvalidArgument, "VolumeContentSource Snapshot is not yet implemented")
+		case *csi.VolumeContentSource_Volume:
+			var srcVolumeID string
+			if volContentSource.GetVolume() != nil {
+				srcVolumeID = volContentSource.GetVolume().GetVolumeId()
+			}
+			srcResourceGroupName, srcAccountName, srcContainerName, _, srcSubscriptionID, err = GetContainerInfo(srcVolumeID)
+			if err != nil {
+				return nil, status.Error(codes.NotFound, err.Error())
+			}
+			srcAccountOptions := &azure.AccountOptions{
+				Name:                srcAccountName,
+				SubscriptionID:      srcSubscriptionID,
+				ResourceGroup:       srcResourceGroupName,
+				GetLatestAccountKey: getLatestAccountKey,
+			}
+			srcAccountSASToken, srcAzcopyAuthEnv, err = d.getAzcopyAuth(ctx, srcAccountName, "", storageEndpointSuffix, srcAccountOptions, secrets, secretName, secretNamespace)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
+			}
+			srcPath = fmt.Sprintf("https://%s.blob.%s/%s", srcAccountName, storageEndpointSuffix, srcContainerName)
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "VolumeContentSource is not recognized: %v", volContentSource)
+		}
+	}
+
 	var accountKey string
 	accountName := account
-	secrets := req.GetSecrets()
 	if len(secrets) == 0 && accountName == "" {
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
@@ -423,30 +467,25 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		secrets = createStorageAccountSecret(accountName, accountKey)
 	}
 
-	// replace pv/pvc name namespace metadata in subDir
-	containerName = replaceWithMap(containerName, containerNameReplaceMap)
-	validContainerName := containerName
-	if validContainerName == "" {
-		validContainerName = volName
-		if containerNamePrefix != "" {
-			validContainerName = containerNamePrefix + "-" + volName
+	dstAzcopyAuthEnv := srcAzcopyAuthEnv
+	dstAccountSASToken := srcAccountSASToken
+	if volContentSource != nil {
+		if srcSubscriptionID != subsID || srcResourceGroupName != resourceGroup || srcAccountName != accountName {
+			if dstAccountSASToken, dstAzcopyAuthEnv, err = d.getAzcopyAuth(ctx, accountName, accountKey, storageEndpointSuffix, accountOptions, secrets, secretName, secretNamespace); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
+			}
 		}
-		validContainerName = getValidContainerName(validContainerName, protocol)
-		setKeyValueInMap(parameters, containerNameField, validContainerName)
 	}
 
-	if req.GetVolumeContentSource() != nil {
-		accountSASToken, authAzcopyEnv, err := d.getAzcopyAuth(ctx, accountName, accountKey, storageEndpointSuffix, accountOptions, secrets, secretName, secretNamespace)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
-		}
-		if err := d.copyVolume(req, accountSASToken, authAzcopyEnv, validContainerName, storageEndpointSuffix); err != nil {
+	klog.V(2).Infof("begin to create container(%s) on account(%s) type(%s) subsID(%s) rg(%s) location(%s) size(%d)", validContainerName, accountName, storageAccountType, subsID, resourceGroup, location, requestGiB)
+	if err := d.CreateBlobContainer(ctx, subsID, resourceGroup, accountName, validContainerName, secrets); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create container(%s) on account(%s) type(%s) rg(%s) location(%s) size(%d), error: %v", validContainerName, accountName, storageAccountType, resourceGroup, location, requestGiB, err)
+	}
+
+	if volContentSource != nil {
+		dstPath := fmt.Sprintf("https://%s.blob.%s/%s", accountName, storageEndpointSuffix, validContainerName)
+		if err := d.copyBlobContainer(dstAzcopyAuthEnv, srcPath, srcAccountSASToken, dstPath, dstAccountSASToken, validContainerName); err != nil {
 			return nil, err
-		}
-	} else {
-		klog.V(2).Infof("begin to create container(%s) on account(%s) type(%s) subsID(%s) rg(%s) location(%s) size(%d)", validContainerName, accountName, storageAccountType, subsID, resourceGroup, location, requestGiB)
-		if err := d.CreateBlobContainer(ctx, subsID, resourceGroup, accountName, validContainerName, secrets); err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to create container(%s) on account(%s) type(%s) rg(%s) location(%s) size(%d), error: %v", validContainerName, accountName, storageAccountType, resourceGroup, location, requestGiB, err)
 		}
 	}
 
@@ -488,7 +527,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			VolumeId:      volumeID,
 			CapacityBytes: req.GetCapacityRange().GetRequiredBytes(),
 			VolumeContext: parameters,
-			ContentSource: req.GetVolumeContentSource(),
+			ContentSource: volContentSource,
 		},
 	}, nil
 }
@@ -755,23 +794,12 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 	})
 }
 
-// CopyBlobContainer copies a blob container in the same storage account
-func (d *Driver) copyBlobContainer(req *csi.CreateVolumeRequest, accountSasToken string, authAzcopyEnv []string, dstContainerName, storageEndpointSuffix string) error {
-	var sourceVolumeID string
-	if req.GetVolumeContentSource() != nil && req.GetVolumeContentSource().GetVolume() != nil {
-		sourceVolumeID = req.GetVolumeContentSource().GetVolume().GetVolumeId()
+// copyBlobContainer copies source volume content into a destination volume
+func (d *Driver) copyBlobContainer(authAzcopyEnv []string, srcPath string, srcAccountSASToken string, dstPath string, dstAccountSASToken string, dstContainerName string) error {
 
+	if srcPath == "" || dstPath == "" || dstContainerName == "" {
+		return fmt.Errorf("srcPath(%s) or dstPath(%s) or dstContainerName(%s) is empty", srcPath, dstPath, dstContainerName)
 	}
-	resourceGroupName, accountName, srcContainerName, _, _, err := GetContainerInfo(sourceVolumeID) //nolint:dogsled
-	if err != nil {
-		return status.Error(codes.NotFound, err.Error())
-	}
-	if srcContainerName == "" || dstContainerName == "" {
-		return fmt.Errorf("srcContainerName(%s) or dstContainerName(%s) is empty", srcContainerName, dstContainerName)
-	}
-
-	srcPath := fmt.Sprintf("https://%s.blob.%s/%s%s", accountName, storageEndpointSuffix, srcContainerName, accountSasToken)
-	dstPath := fmt.Sprintf("https://%s.blob.%s/%s%s", accountName, storageEndpointSuffix, dstContainerName, accountSasToken)
 
 	jobState, percent, err := d.azcopy.GetAzcopyJob(dstContainerName, authAzcopyEnv)
 	klog.V(2).Infof("azcopy job status: %s, copy percent: %s%%, error: %v", jobState, percent, err)
@@ -781,9 +809,9 @@ func (d *Driver) copyBlobContainer(req *csi.CreateVolumeRequest, accountSasToken
 	case util.AzcopyJobRunning:
 		return fmt.Errorf("wait for the existing AzCopy job to complete, current copy percentage is %s%%", percent)
 	case util.AzcopyJobNotFound:
-		klog.V(2).Infof("copy blob container %s to %s", srcContainerName, dstContainerName)
+		klog.V(2).Infof("copy blob container %s to %s", srcPath, dstContainerName)
 		execFunc := func() error {
-			cmd := exec.Command("azcopy", "copy", srcPath, dstPath, "--recursive", "--check-length=false")
+			cmd := exec.Command("azcopy", "copy", srcPath+srcAccountSASToken, dstPath+dstAccountSASToken, "--recursive", "--check-length=false")
 			if len(authAzcopyEnv) > 0 {
 				cmd.Env = append(os.Environ(), authAzcopyEnv...)
 			}
@@ -794,30 +822,17 @@ func (d *Driver) copyBlobContainer(req *csi.CreateVolumeRequest, accountSasToken
 		}
 		timeoutFunc := func() error {
 			_, percent, _ := d.azcopy.GetAzcopyJob(dstContainerName, authAzcopyEnv)
-			return fmt.Errorf("timeout waiting for copy blob container %s to %s complete, current copy percent: %s%%", srcContainerName, dstContainerName, percent)
+			return fmt.Errorf("timeout waiting for copy blob container %s to %s complete, current copy percent: %s%%", srcPath, dstContainerName, percent)
 		}
 		copyErr := util.WaitUntilTimeout(time.Duration(d.waitForAzCopyTimeoutMinutes)*time.Minute, execFunc, timeoutFunc)
 		if copyErr != nil {
-			klog.Warningf("CopyBlobContainer(%s, %s, %s) failed with error: %v", resourceGroupName, accountName, dstPath, copyErr)
+			klog.Warningf("CopyBlobContainer(%s, %s, %s) failed with error: %v", srcPath, dstPath, dstContainerName, copyErr)
 		} else {
-			klog.V(2).Infof("copied blob container %s to %s successfully", srcContainerName, dstContainerName)
+			klog.V(2).Infof("copied blob container %s to %s successfully", srcPath, dstContainerName)
 		}
 		return copyErr
 	}
 	return err
-}
-
-// copyVolume copies a volume form volume or snapshot, snapshot is not supported now
-func (d *Driver) copyVolume(req *csi.CreateVolumeRequest, accountSASToken string, authAzcopyEnv []string, dstContainerName, storageEndpointSuffix string) error {
-	vs := req.VolumeContentSource
-	switch vs.Type.(type) {
-	case *csi.VolumeContentSource_Snapshot:
-		return status.Errorf(codes.InvalidArgument, "copy volume from volumeSnapshot is not supported")
-	case *csi.VolumeContentSource_Volume:
-		return d.copyBlobContainer(req, accountSASToken, authAzcopyEnv, dstContainerName, storageEndpointSuffix)
-	default:
-		return status.Errorf(codes.InvalidArgument, "%v is not a proper volume source", vs)
-	}
 }
 
 // authorizeAzcopyWithIdentity returns auth env for azcopy using cluster identity

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -793,12 +793,9 @@ func TestCreateVolume(t *testing.T) {
 				defer ctrl.Finish()
 
 				m := util.NewMockEXEC(ctrl)
-				listStr := "no error"
-				m.EXPECT().RunCommand(gomock.Any(), gomock.Any()).Return(listStr, nil)
-
 				d.azcopy.ExecCmd = m
 
-				expectedErr := status.Errorf(codes.InvalidArgument, "copy volume from volumeSnapshot is not supported")
+				expectedErr := status.Errorf(codes.InvalidArgument, "VolumeContentSource Snapshot is not yet implemented")
 				_, err := d.CreateVolume(context.Background(), req)
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
@@ -858,9 +855,6 @@ func TestCreateVolume(t *testing.T) {
 				defer ctrl.Finish()
 
 				m := util.NewMockEXEC(ctrl)
-				listStr := "no error"
-				m.EXPECT().RunCommand(gomock.Any(), gomock.Any()).Return(listStr, nil)
-
 				d.azcopy.ExecCmd = m
 
 				expectedErr := status.Errorf(codes.NotFound, "error parsing volume id: \"unit-test\", should at least contain two #")
@@ -1531,132 +1525,38 @@ func TestDeleteBlobContainer(t *testing.T) {
 }
 
 func TestCopyVolume(t *testing.T) {
-	stdVolumeCapability := &csi.VolumeCapability{
-		AccessType: &csi.VolumeCapability_Mount{
-			Mount: &csi.VolumeCapability_MountVolume{},
-		},
-	}
-	stdVolumeCapabilities := []*csi.VolumeCapability{
-		stdVolumeCapability,
-	}
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
 	}{
 		{
-			name: "copy volume from volumeSnapshot is not supported",
+			name: "src path is empty",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				mp := map[string]string{}
-
-				volumeSnapshotSource := &csi.VolumeContentSource_SnapshotSource{
-					SnapshotId: "unit-test",
-				}
-				volumeContentSourceSnapshotSource := &csi.VolumeContentSource_Snapshot{
-					Snapshot: volumeSnapshotSource,
-				}
-				volumecontensource := csi.VolumeContentSource{
-					Type: volumeContentSourceSnapshotSource,
-				}
-				req := &csi.CreateVolumeRequest{
-					Name:                "unit-test",
-					VolumeCapabilities:  stdVolumeCapabilities,
-					Parameters:          mp,
-					VolumeContentSource: &volumecontensource,
-				}
-
-				expectedErr := status.Errorf(codes.InvalidArgument, "copy volume from volumeSnapshot is not supported")
-				err := d.copyVolume(req, "", nil, "", "core.windows.net")
+				expectedErr := fmt.Errorf("srcPath() or dstPath(dstPath) or dstContainerName(dstContainer) is empty")
+				err := d.copyBlobContainer([]string{}, "", "", "dstPath", "", "dstContainer")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 			},
 		},
 		{
-			name: "copy volume from volume not found",
+			name: "dst path is empty",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				mp := map[string]string{}
-
-				volumeSource := &csi.VolumeContentSource_VolumeSource{
-					VolumeId: "unit-test",
-				}
-				volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-					Volume: volumeSource,
-				}
-				volumecontensource := csi.VolumeContentSource{
-					Type: volumeContentSourceVolumeSource,
-				}
-
-				req := &csi.CreateVolumeRequest{
-					Name:                "unit-test",
-					VolumeCapabilities:  stdVolumeCapabilities,
-					Parameters:          mp,
-					VolumeContentSource: &volumecontensource,
-				}
-
-				expectedErr := status.Errorf(codes.NotFound, "error parsing volume id: \"unit-test\", should at least contain two #")
-				err := d.copyVolume(req, "", nil, "dstContainer", "core.windows.net")
+				expectedErr := fmt.Errorf("srcPath(srcPath) or dstPath() or dstContainerName(dstContainer) is empty")
+				err := d.copyBlobContainer([]string{}, "srcPath", "", "", "", "dstContainer")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 			},
 		},
 		{
-			name: "src blob container is empty",
+			name: "dst container is empty",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				mp := map[string]string{}
-
-				volumeSource := &csi.VolumeContentSource_VolumeSource{
-					VolumeId: "rg#unit-test##",
-				}
-				volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-					Volume: volumeSource,
-				}
-				volumecontensource := csi.VolumeContentSource{
-					Type: volumeContentSourceVolumeSource,
-				}
-
-				req := &csi.CreateVolumeRequest{
-					Name:                "unit-test",
-					VolumeCapabilities:  stdVolumeCapabilities,
-					Parameters:          mp,
-					VolumeContentSource: &volumecontensource,
-				}
-
-				expectedErr := fmt.Errorf("srcContainerName() or dstContainerName(dstContainer) is empty")
-				err := d.copyVolume(req, "", nil, "dstContainer", "core.windows.net")
-				if !reflect.DeepEqual(err, expectedErr) {
-					t.Errorf("Unexpected error: %v", err)
-				}
-			},
-		},
-		{
-			name: "dst blob container is empty",
-			testFunc: func(t *testing.T) {
-				d := NewFakeDriver()
-				mp := map[string]string{}
-
-				volumeSource := &csi.VolumeContentSource_VolumeSource{
-					VolumeId: "vol_1#f5713de20cde511e8ba4900#fileshare#",
-				}
-				volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-					Volume: volumeSource,
-				}
-				volumecontensource := csi.VolumeContentSource{
-					Type: volumeContentSourceVolumeSource,
-				}
-
-				req := &csi.CreateVolumeRequest{
-					Name:                "unit-test",
-					VolumeCapabilities:  stdVolumeCapabilities,
-					Parameters:          mp,
-					VolumeContentSource: &volumecontensource,
-				}
-
-				expectedErr := fmt.Errorf("srcContainerName(fileshare) or dstContainerName() is empty")
-				err := d.copyVolume(req, "", nil, "", "core.windows.net")
+				expectedErr := fmt.Errorf("srcPath(srcPath) or dstPath(dstPath) or dstContainerName() is empty")
+				err := d.copyBlobContainer([]string{}, "srcPath", "", "dstPath", "", "")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -1666,25 +1566,6 @@ func TestCopyVolume(t *testing.T) {
 			name: "azcopy job is already completed",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				mp := map[string]string{}
-
-				volumeSource := &csi.VolumeContentSource_VolumeSource{
-					VolumeId: "vol_1#f5713de20cde511e8ba4900#fileshare#",
-				}
-				volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-					Volume: volumeSource,
-				}
-				volumecontensource := csi.VolumeContentSource{
-					Type: volumeContentSourceVolumeSource,
-				}
-
-				req := &csi.CreateVolumeRequest{
-					Name:                "unit-test",
-					VolumeCapabilities:  stdVolumeCapabilities,
-					Parameters:          mp,
-					VolumeContentSource: &volumecontensource,
-				}
-
 				ctrl := gomock.NewController(t)
 				defer ctrl.Finish()
 
@@ -1692,13 +1573,13 @@ func TestCopyVolume(t *testing.T) {
 				listStr := "JobId: ed1c3833-eaff-fe42-71d7-513fb065a9d9\nStart Time: Monday, 07-Aug-23 03:29:54 UTC\nStatus: Completed\nCommand: copy https://{accountName}.file.core.windows.net/{srcFileshare}{SAStoken} https://{accountName}.file.core.windows.net/{dstFileshare}{SAStoken} --recursive --check-length=false"
 				m.EXPECT().RunCommand(gomock.Eq("azcopy jobs list | grep dstContainer -B 3"), gomock.Any()).Return(listStr, nil)
 				// if test.enableShow {
-				// 	m.EXPECT().RunCommand(gomock.Not("azcopy jobs list | grep dstContainer -B 3")).Return(test.showStr, test.showErr)
+				//     m.EXPECT().RunCommand(gomock.Not("azcopy jobs list | grep dstContainer -B 3")).Return(test.showStr, test.showErr)
 				// }
 
 				d.azcopy.ExecCmd = m
 
 				var expectedErr error
-				err := d.copyVolume(req, "sastoken", nil, "dstContainer", "core.windows.net")
+				err := d.copyBlobContainer([]string{}, "srcPath", "", "dstPath", "", "dstContainer")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}
@@ -1708,25 +1589,6 @@ func TestCopyVolume(t *testing.T) {
 			name: "azcopy job is in progress",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				mp := map[string]string{}
-
-				volumeSource := &csi.VolumeContentSource_VolumeSource{
-					VolumeId: "vol_1#f5713de20cde511e8ba4900#fileshare#",
-				}
-				volumeContentSourceVolumeSource := &csi.VolumeContentSource_Volume{
-					Volume: volumeSource,
-				}
-				volumecontensource := csi.VolumeContentSource{
-					Type: volumeContentSourceVolumeSource,
-				}
-
-				req := &csi.CreateVolumeRequest{
-					Name:                "unit-test",
-					VolumeCapabilities:  stdVolumeCapabilities,
-					Parameters:          mp,
-					VolumeContentSource: &volumecontensource,
-				}
-
 				ctrl := gomock.NewController(t)
 				defer ctrl.Finish()
 
@@ -1738,7 +1600,7 @@ func TestCopyVolume(t *testing.T) {
 				d.azcopy.ExecCmd = m
 
 				expectedErr := fmt.Errorf("wait for the existing AzCopy job to complete, current copy percentage is 50.0%%")
-				err := d.copyVolume(req, "sastoken", nil, "dstContainer", "core.windows.net")
+				err := d.copyBlobContainer([]string{}, "srcPath", "", "dstPath", "", "dstContainer")
 				if !reflect.DeepEqual(err, expectedErr) {
 					t.Errorf("Unexpected error: %v", err)
 				}


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`CreateVolume()` now follows the established volume provisioning logic when cloning volume content.

This ensures the created volume has the expected configuration, metadata and content.

**Which issue(s) this PR fixes**:

- Resolves issue #1495
- Prevents SAS tokens from being logged in clear text during volume cloning
- Avoids duplication of azcopy jobs when `containerName` or `containerNamePrefix` are specified

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:

- Volumes are now provisioned correctly when cloning