### PR TITLE
fix: volume cloning between different storage account for BlobAccessTierNotSupportedForAccountType error

### DIFF
--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -802,7 +802,7 @@ func (d *Driver) copyBlobContainer(authAzcopyEnv []string, srcPath string, srcAc
 	case util.AzcopyJobNotFound:
 		klog.V(2).Infof("copy blob container %s to %s", srcPath, dstContainerName)
 		execFunc := func() error {
-			cmd := exec.Command("azcopy", "copy", srcPath+srcAccountSASToken, dstPath+dstAccountSASToken, "--recursive", "--check-length=false")
+			cmd := exec.Command("azcopy", "copy", srcPath+srcAccountSASToken, dstPath+dstAccountSASToken, "--recursive", "--check-length=false", "--s2s-preserve-access-tier=false")
 			if len(authAzcopyEnv) > 0 {
 				cmd.Env = append(os.Environ(), authAzcopyEnv...)
 			}

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1006,4 +1006,79 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		}
 		test.Run(ctx, cs, ns)
 	})
+
+	ginkgo.It("should clone a volume from an existing NFSv3 volume to another storage class [nfs]", func(ctx ginkgo.SpecContext) {
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					ClaimSize: "10Gi",
+					MountOptions: []string{
+						"nconnect=8",
+					},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		podWithClonedVolume := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data",
+		}
+		test := testsuites.DynamicallyProvisionedVolumeCloningTest{
+			CSIDriver:           testDriver,
+			Pod:                 pod,
+			PodWithClonedVolume: podWithClonedVolume,
+			StorageClassParameters: map[string]string{
+				"skuName":              "Premium_LRS",
+				"protocol":             "nfs",
+				"mountPermissions":     "0755",
+				"allowsharedkeyaccess": "true",
+			},
+			ClonedStorageClassParameters: map[string]string{
+				"skuName":              "Standard_LRS",
+				"protocol":             "nfs",
+				"mountPermissions":     "0755",
+				"allowsharedkeyaccess": "true",
+			},
+		}
+		test.Run(ctx, cs, ns)
+	})
+
+	ginkgo.It("should clone a volume from an existing blobfuse2 volume to another storage class [fuse2]", func(ctx ginkgo.SpecContext) {
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					ClaimSize: "10Gi",
+					MountOptions: []string{
+						"-o allow_other",
+						"--virtual-directory=true", // blobfuse2 mount options
+					},
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+				},
+			},
+		}
+		podWithClonedVolume := testsuites.PodDetails{
+			Cmd: "grep 'hello world' /mnt/test-1/data",
+		}
+		test := testsuites.DynamicallyProvisionedVolumeCloningTest{
+			CSIDriver:           testDriver,
+			Pod:                 pod,
+			PodWithClonedVolume: podWithClonedVolume,
+			StorageClassParameters: map[string]string{
+				"skuName":  "Standard_LRS",
+				"protocol": "fuse2",
+			},
+			ClonedStorageClassParameters: map[string]string{
+				"skuName":  "Premium_LRS",
+				"protocol": "fuse2",
+			},
+		}
+		test.Run(ctx, cs, ns)
+	})
 })

--- a/test/e2e/testsuites/dynamically_provisioned_volume_cloning_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_volume_cloning_tester.go
@@ -29,11 +29,12 @@ import (
 // DynamicallyProvisionedVolumeCloningTest will provision required StorageClass(es), PVC(s) and Pod(s)
 // ClonedVolumeSize optional for when testing for cloned volume with different size to the original volume
 type DynamicallyProvisionedVolumeCloningTest struct {
-	CSIDriver              driver.DynamicPVTestDriver
-	Pod                    PodDetails
-	PodWithClonedVolume    PodDetails
-	ClonedVolumeSize       string
-	StorageClassParameters map[string]string
+	CSIDriver                    driver.DynamicPVTestDriver
+	Pod                          PodDetails
+	PodWithClonedVolume          PodDetails
+	ClonedVolumeSize             string
+	StorageClassParameters       map[string]string
+	ClonedStorageClassParameters map[string]string
 }
 
 func (t *DynamicallyProvisionedVolumeCloningTest) Run(ctx context.Context, client clientset.Interface, namespace *v1.Namespace) {
@@ -69,7 +70,11 @@ func (t *DynamicallyProvisionedVolumeCloningTest) Run(ctx context.Context, clien
 	}
 
 	t.PodWithClonedVolume.Volumes = []VolumeDetails{clonedVolume}
-	tpod, cleanups = t.PodWithClonedVolume.SetupWithDynamicVolumes(ctx, client, namespace, t.CSIDriver, t.StorageClassParameters)
+	clonedStorageClassParameters := t.StorageClassParameters
+	if t.ClonedStorageClassParameters != nil {
+		clonedStorageClassParameters = t.ClonedStorageClassParameters
+	}
+	tpod, cleanups = t.PodWithClonedVolume.SetupWithDynamicVolumes(ctx, client, namespace, t.CSIDriver, clonedStorageClassParameters)
 	for i := range cleanups {
 		defer cleanups[i](ctx)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:

fix: volume cloning between different storage account for BlobAccessTierNotSupportedForAccountType error
azcopy between different storage account has this issue:
![image](https://github.com/user-attachments/assets/8d520133-a609-4067-bd1c-0c9dea9cd1d9)
referring to https://github.com/Azure/azure-storage-azcopy/issues/327 to fix
Also in this issue comment: https://github.com/Azure/azure-storage-azcopy/issues/327#issuecomment-481824121, azcopy may automatically replicate the source blob's tier info to the destination, so create blob container before azcopy instead of using azcopy to create container is more correct.
add volume cloning between different account e2e test

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
