### PR TITLE
feat: install blobfuse2 for arm64

### DIFF
--- a/pkg/blobplugin/Dockerfile
+++ b/pkg/blobplugin/Dockerfile
@@ -73,6 +73,11 @@ RUN if [ "$ARCH" = "amd64" ] ; then \
     && apt update \
     && apt install -y blobfuse blobfuse2 fuse; fi
 
+RUN if [ "$ARCH" = "arm64" ] ; then \
+    dpkg -i /blobfuse-proxy/packages-microsoft-prod-22.04.deb \
+    && apt update \
+    && apt install -y fuse3 blobfuse2; fi
+
 LABEL maintainers="andyzhangx"
 LABEL description="Azure Blob Storage CSI driver"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Installs blobfuse2 for arm64 build of the blobplugin docker image. Needed to support using fuse2 protocol on arm64.

**Which issue(s) this PR fixes**:
Fixes #1618

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
