### PR TITLE
doc: Azure Linux node does not support nconnect option

### DIFF
--- a/deploy/example/nfs/README.md
+++ b/deploy/example/nfs/README.md
@@ -22,7 +22,7 @@ allowVolumeExpansion: true
 parameters:
   protocol: nfs
 mountOptions:
-  - nconnect=4
+  - nconnect=4  # Azure Linux node does not support nconnect option
 ```
 
 run following command to create a storage class:

--- a/deploy/example/pv-blobfuse-nfs.yaml
+++ b/deploy/example/pv-blobfuse-nfs.yaml
@@ -13,7 +13,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: blob-nfs
   mountOptions:
-    - nconnect=4
+    - nconnect=4  # Azure Linux node does not support nconnect option
   csi:
     driver: blob.csi.azure.com
     # make sure volumeid is unique for every storage blob container in the cluster

--- a/deploy/example/storageclass-blob-nfs.yaml
+++ b/deploy/example/storageclass-blob-nfs.yaml
@@ -9,4 +9,4 @@ parameters:
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 mountOptions:
-  - nconnect=4
+  - nconnect=4  # Azure Linux node does not support nconnect option


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
doc: Azure Linux node does not support nconnect option

you could get following nfs mount error on Azure Linux node:
```
  Warning  FailedMount       26s (x8 over 90s)  kubelet            MountVolume.MountDevice failed for volume "pvc-b4bb90f5-0ab5-4861-88b1-f983b7d22b99" : rpc error: code = Internal desc = volume(MC_andy-aks129_andy-aks129_eastus2#nfs40fc7f659b604080af74#pvc-b4bb90f5-0ab5-4861-88b1-f983b7d22b99##default#) mount "nfs40fc7f659b604080af74.blob.core.windows.net:/nfs40fc7f659b604080af74/pvc-b4bb90f5-0ab5-4861-88b1-f983b7d22b99" on "/var/lib/kubelet/plugins/kubernetes.io/csi/blob.csi.azure.com/841ce093838cb0710d083145a4b3fb2c559989d43d6964e8efe6cea838e324b4/globalmount" failed with mount failed: exit status 1
Mounting command: mount
Mounting arguments: -t aznfs -o nconnect=4,sec=sys,vers=3,nolock nfs40fc7f659b604080af74.blob.core.windows.net:/nfs40fc7f659b604080af74/pvc-b4bb90f5-0ab5-4861-88b1-f983b7d22b99 /var/lib/kubelet/plugins/kubernetes.io/csi/blob.csi.azure.com/841ce093838cb0710d083145a4b3fb2c559989d43d6964e8efe6cea838e324b4/globalmount
Output: ^[[2;31mnconnect option needs NFS client with Azure nconnect support!^[[0m
^[[2;31mMount failed!^[[0m

Please refer to http://aka.ms/blobmounterror for possible causes and solutions for mount errors.
```

https://learn.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-performance#increase-the-number-of-tcp-connections

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
