### PR TITLE
Fix: swapped the wrong ne to an eq when checking if it is a fedora

### DIFF
--- a/charts/v1.26.0/blob-csi-driver/templates/csi-blob-node.yaml
+++ b/charts/v1.26.0/blob-csi-driver/templates/csi-blob-node.yaml
@@ -243,7 +243,7 @@ spec:
               mountPath: /etc/ssl/certs
               readOnly: true
             {{- end }}
-            {{- if and (eq .Values.cloud "AzureStackCloud") (ne .Values.linux.distro "fedora") }}
+            {{- if and (eq .Values.cloud "AzureStackCloud") (eq .Values.linux.distro "fedora") }}
             - name: ssl
               mountPath: /etc/ssl/certs
               readOnly: true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently when using the helm chart with `AzureStackCloud` option it will fail with a duplicate volume mount because of some boolean logic mistake. 

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
