### PR TITLE
fix: only use the permission bits for chmod

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1092,9 +1092,11 @@ func chmodIfPermissionMismatch(targetPath string, mode os.FileMode) error {
 		return err
 	}
 	perm := info.Mode() & os.ModePerm
-	if perm != mode {
-		klog.V(2).Infof("chmod targetPath(%s, mode:0%o) with permissions(0%o)", targetPath, info.Mode(), mode)
-		if err := os.Chmod(targetPath, mode); err != nil {
+	expectedPerms := mode & os.ModePerm
+	if perm != expectedPerms {
+		klog.V(2).Infof("chmod targetPath(%s, mode:0%o) with permissions(0%o)", targetPath, info.Mode(), expectedPerms)
+		// only change the permission mode bits, keep the other bits as is
+		if err := os.Chmod(targetPath, (info.Mode()&^os.ModePerm)|os.FileMode(expectedPerms)); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1516,11 +1516,23 @@ func TestChmodIfPermissionMismatch(t *testing.T) {
 	_ = os.MkdirAll(permissionMismatchPath, os.FileMode(0721))
 	defer os.RemoveAll(permissionMismatchPath)
 
+	permissionMatchGidMismatchPath, _ := getWorkDirPath("permissionMatchGidMismatchPath")
+	_ = os.MkdirAll(permissionMatchGidMismatchPath, os.FileMode(0755))
+	_ = os.Chmod(permissionMatchGidMismatchPath, 0755|os.ModeSetgid) // Setgid bit is set
+	defer os.RemoveAll(permissionMatchGidMismatchPath)
+
+	permissionMismatchGidMismatch, _ := getWorkDirPath("permissionMismatchGidMismatch")
+	_ = os.MkdirAll(permissionMismatchGidMismatch, os.FileMode(0721))
+	_ = os.Chmod(permissionMismatchGidMismatch, 0721|os.ModeSetgid) // Setgid bit is set
+	defer os.RemoveAll(permissionMismatchGidMismatch)
+
 	tests := []struct {
-		desc          string
-		path          string
-		mode          os.FileMode
-		expectedError error
+		desc           string
+		path           string
+		mode           os.FileMode
+		expectedPerms  os.FileMode
+		expectedGidBit bool
+		expectedError  error
 	}{
 		{
 			desc:          "Invalid path",
@@ -1529,16 +1541,52 @@ func TestChmodIfPermissionMismatch(t *testing.T) {
 			expectedError: fmt.Errorf("CreateFile invalid-path: The system cannot find the file specified"),
 		},
 		{
-			desc:          "permission matching path",
-			path:          permissionMatchingPath,
-			mode:          0755,
-			expectedError: nil,
+			desc:           "permission matching path",
+			path:           permissionMatchingPath,
+			mode:           0755,
+			expectedPerms:  0755,
+			expectedGidBit: false,
+			expectedError:  nil,
 		},
 		{
-			desc:          "permission mismatch path",
-			path:          permissionMismatchPath,
-			mode:          0755,
-			expectedError: nil,
+			desc:           "permission mismatch path",
+			path:           permissionMismatchPath,
+			mode:           0755,
+			expectedPerms:  0755,
+			expectedGidBit: false,
+			expectedError:  nil,
+		},
+		{
+			desc:           "permission mismatch path",
+			path:           permissionMismatchPath,
+			mode:           0755,
+			expectedPerms:  0755,
+			expectedGidBit: false,
+			expectedError:  nil,
+		},
+		{
+			desc:           "only match the permission mode bits",
+			path:           permissionMatchGidMismatchPath,
+			mode:           0755,
+			expectedPerms:  0755,
+			expectedGidBit: true,
+			expectedError:  nil,
+		},
+		{
+			desc:           "only change the permission mode bits when gid is set",
+			path:           permissionMismatchGidMismatch,
+			mode:           0755,
+			expectedPerms:  0755,
+			expectedGidBit: true,
+			expectedError:  nil,
+		},
+		{
+			desc:           "only change the permission mode bits when gid is not set but mode bits have gid set",
+			path:           permissionMismatchPath,
+			mode:           02755,
+			expectedPerms:  0755,
+			expectedGidBit: false,
+			expectedError:  nil,
 		},
 	}
 
@@ -1549,7 +1597,19 @@ func TestChmodIfPermissionMismatch(t *testing.T) {
 				t.Errorf("test[%s]: unexpected error: %v, expected error: %v", test.desc, err, test.expectedError)
 			}
 		}
+
+		if test.expectedError == nil {
+			info, _ := os.Lstat(test.path)
+			if test.expectedError == nil && (info.Mode()&os.ModePerm != test.expectedPerms) {
+				t.Errorf("test[%s]: unexpected perms: %v, expected perms: %v, ", test.desc, info.Mode()&os.ModePerm, test.expectedPerms)
+			}
+
+			if (info.Mode()&os.ModeSetgid != 0) != test.expectedGidBit {
+				t.Errorf("test[%s]: unexpected gid bit: %v, expected gid bit: %v", test.desc, info.Mode()&os.ModeSetgid != 0, test.expectedGidBit)
+			}
+		}
 	}
+
 }
 
 // getWorkDirPath returns the path to the current working directory

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -1508,6 +1509,10 @@ func TestIsSupportedContainerNamePrefix(t *testing.T) {
 }
 
 func TestChmodIfPermissionMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
 	permissionMatchingPath, _ := getWorkDirPath("permissionMatchingPath")
 	_ = makeDir(permissionMatchingPath)
 	defer os.RemoveAll(permissionMatchingPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
If the volumeattributes.mountpermissions are set for an nfs volume, we check if the permissions on the mount targetPath are the same as the expected mountPermissions. When this check is made currently, the targetPath mode bits are masked to use only the permission bits.
We should do the same with the mountPermissions bits to ensure that there isn't an unnecessary mismatch.
After the comparison, if the mount permissions are different, this PR ensures that only mount permissions change with the chmod operation and the rest of the bits like gid remain as is.

Related PR: https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/2600

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
