### PR TITLE
Revert "fix: ignore specific blobfuse version install failure"

### DIFF
--- a/pkg/blobfuse-proxy/install-proxy.sh
+++ b/pkg/blobfuse-proxy/install-proxy.sh
@@ -83,7 +83,7 @@ then
   fi
 
   echo "begin to install ${pkg_list}"
-  $HOST_CMD apt-get install -y $pkg_list || true
+  $HOST_CMD apt-get install -y $pkg_list
   $HOST_CMD rm -f /etc/packages-microsoft-prod.deb
 fi
 


### PR DESCRIPTION
Reverts kubernetes-sigs/blob-csi-driver#1508

we could revert now since https://github.com/kubernetes-sigs/blob-csi-driver/pull/2089 could fix the issue more gracefully.

Fixes #2098