### PR TITLE
[release-1.25] feat: support blobStorageAccountType parameter in storage class or pv

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -85,6 +85,7 @@ const (
 	storageSPNClientIDField        = "azurestoragespnclientid"
 	storageSPNTenantIDField        = "azurestoragespntenantid"
 	storageAuthTypeField           = "azurestorageauthtype"
+	blobStorageAccountTypeField    = "blobstorageaccounttype"
 	storageAuthTypeMSI             = "msi"
 	storageIdentityClientIDField   = "azurestorageidentityclientid"
 	storageIdentityObjectIDField   = "azurestorageidentityobjectid"

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -192,6 +192,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		case tenantIDField:
 		case msiEndpointField:
 		case storageAADEndpointField:
+		case blobStorageAccountTypeField:
 			// no op, only used in NodeStageVolume
 		case storageEndpointSuffixField:
 			storageEndpointSuffix = v

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -449,6 +449,7 @@ func TestCreateVolume(t *testing.T) {
 				mp[mountPermissionsField] = "0750"
 				mp[storageAuthTypeField] = "msi"
 				mp[storageIdentityClientIDField] = "msi"
+				mp[blobStorageAccountTypeField] = "adls"
 				mp[clientIDField] = "clientID"
 				mp[mountWithWITokenField] = "true"
 				mp[tenantIDField] = "tenantID"

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -118,10 +118,11 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
-				"skuName":             "Standard_LRS",
-				"secretNamespace":     "default",
-				"containerNamePrefix": "nameprefix",
-				"accessTier":          "Cool",
+				"skuName":                "Standard_LRS",
+				"secretNamespace":        "default",
+				"containerNamePrefix":    "nameprefix",
+				"accessTier":             "Cool",
+				"blobStorageAccountType": "block",
 			},
 		}
 		test.Run(ctx, cs, ns)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support blobStorageAccountType parameter in storage class or pv

cherrypick of https://github.com/kubernetes-sigs/blob-csi-driver/pull/2102

usually we don't need this parameter setting in sc or pv since from blobfuse 2.4.2, the blobfuse2 driver would auto detect storage account type, while if user still wants to specify this account type in edge case, this PR will support this scenario:

```
AZURE_STORAGE_ACCOUNT_TYPE: Specifies the account type 'block' or 'adls'
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
feat: support blobStorageAccountType parameter in storage class or pv
```
