### PR TITLE
[release-1.26]🐞 fix: shasum in blobfuse-proxy installer for Flatcar, fix PATH in blobfuse-proxy.service

### DIFF
--- a/pkg/blobfuse-proxy/install-proxy-rhcos.sh
+++ b/pkg/blobfuse-proxy/install-proxy-rhcos.sh
@@ -101,7 +101,7 @@ if [ "${INSTALL_BLOBFUSE_PROXY}" = "true" ];then
   sed -i "s|/usr/bin/blobfuse-proxy|${BIN_PATH}/blobfuse-proxy|g" /blobfuse-proxy/blobfuse-proxy.service
   if [ "${BIN_PATH}" != "/usr/local/bin" ]; then
     echo "add \"PATH=${BIN_PATH}:\$PATH\" in blobfuse-proxy.service ExecStart."
-    sed "s,^ExecStart[[:space:]]*=\\(.*\\)\$,ExecStart=/usr/bin/bash -c \"PATH=${BIN_PATH}:\$PATH \\1\"," \
+    sed -i "s,^ExecStart[[:space:]]*=\\(.*\\)\$,ExecStart=/usr/bin/bash -c \"PATH=${BIN_PATH}:\$PATH \\1\"," \
       /blobfuse-proxy/blobfuse-proxy.service
   fi
   if [ -f "/host/etc/systemd/system/blobfuse-proxy.service" ];then


### PR DESCRIPTION
The blobfuse-proxy installer script used with Flatcar, install-proxy-rhcos.sh, uses sha256sum to check whether blobfuse binaries need to be (re-)installed. If the checksum of blobfuse2 on the host and blobfuse2 shipped with the container differ, the host blobfuse2 is replaced.

However, for Flatcar, we use a custom name for the blobfuse2 binary on the host ("blobfuse2.bin") and ship a wrapper script named "blobfuse2" to update the linker path for blobfuse2. The shasum check did not account for this and inadvertently generated a checksum for the wrapper script instead of the actual binary.

Additionally, it fixes an issue introduced with the original Flatcar support PR in https://github.com/kubernetes-sigs/blob-csi-driver/pull/2209/commits/0f3078073733cd44c55f3c034d62923150a7004d, which modifies the PATH environment variable correctly for `blobfuse-proxy/blobfuse-proxy.service` but did not actually commit those changes to the service unit file.

This PR fixes both.

Backport of https://github.com/kubernetes-sigs/blob-csi-driver/pull/2216 to release-1.26.

/kind bug