### PR TITLE
fix: snapshot restore and volume clone failure in some new sovereign …

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -268,6 +268,9 @@ type Driver struct {
 	waitForAzCopyTimeoutMinutes int
 	// azcopy for provide exec mock for ut
 	azcopy *util.Azcopy
+
+	// if azcopy has to trust the driver's supplying endpoint
+	requiredAzCopyToTrust bool
 }
 
 // NewDriver Creates a NewCSIDriver object. Assumes vendor version is equal to driver version &
@@ -326,6 +329,12 @@ func NewDriver(options *DriverOptions, kubeClient kubernetes.Interface, cloud *s
 	if d.subnetCache, err = azcache.NewTimedCache(10*time.Minute, getter, false); err != nil {
 		klog.Fatalf("%v", err)
 	}
+
+	requiredAzCopyToTrust := d.getStorageEndPointSuffix() != "" && !strings.Contains(azcopyTrustedSuffixesAAD, d.getStorageEndPointSuffix())
+	if requiredAzCopyToTrust {
+		klog.V(2).Infof("storage endpoint suffix %s is not in azcopy trusted suffixes, azcopy will trust it temporarily during volume clone and snapshot restore", d.getStorageEndPointSuffix())
+	}
+	d.requiredAzCopyToTrust = requiredAzCopyToTrust
 
 	d.mounter = &mount.SafeFormatAndMount{
 		Interface: mount.New(""),

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -61,6 +61,9 @@ const (
 	authorizationPermissionMismatch = "AuthorizationPermissionMismatch"
 
 	createdByMetadata = "createdBy"
+
+	// refer https://github.com/Azure/azure-storage-azcopy/wiki/azcopy
+	azcopyTrustedSuffixesAAD = "*.core.windows.net;*.core.chinacloudapi.cn;*.core.cloudapi.de;*.core.usgovcloudapi.net;*.storage.azure.net"
 )
 
 // CreateVolume provisions a volume
@@ -869,6 +872,11 @@ func (d *Driver) copyVolume(ctx context.Context, req *csi.CreateVolumeRequest, a
 
 // execAzcopyCopy exec azcopy copy command
 func (d *Driver) execAzcopyCopy(srcPath, dstPath string, azcopyCopyOptions, authAzcopyEnv []string) ([]byte, error) {
+	// Use --trusted-microsoft-suffixes option to avoid failure caused by
+	if d.requiredAzCopyToTrust {
+		azcopyCopyOptions = append(azcopyCopyOptions, fmt.Sprintf("--trusted-microsoft-suffixes=%s", d.getStorageEndPointSuffix()))
+	}
+
 	cmd := exec.Command("azcopy", "copy", srcPath, dstPath)
 	cmd.Args = append(cmd.Args, azcopyCopyOptions...)
 	if len(authAzcopyEnv) > 0 {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

We use azcopy during volume clone. Azcopy trusts known Microsoft's endpoint suffixes. When a new endpoint is added, AzCopy fails saying it is not trustable & so volume provisioning fails. Since Azure File CSI Driver knows the trusted new endpoint through the config & in such case if the new endpoint is not in azcopy known list, we will use the option that azcopy provides to pass new suffixes

Without this PR, we need to release new version until which the volume clone is not possible

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
