### PR TITLE
doc: add type reminder for `volumeAttributes.mountWithWorkloadIdentityToken`

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -132,7 +132,7 @@ volumeAttributes.AzureStorageSPNTenantID | SPN Tenant ID |  | No |
 volumeAttributes.AzureStorageAADEndpoint | AADEndpoint |  | No |
 --- | **Following parameters are only for feature: blobfuse [Workload Identity auth](../docs/workload-identity-static-pv-mount.md)** | --- | --- |
 volumeAttributes.ClientID | clientid of the managed identity assigned to the storage account |  | No |
-volumeAttributes.mountWithWorkloadIdentityToken (Preview) | indicates whether performing blobfuse mount with workload identity token | `true`,`false` | No | `false` (limitation: the workload identity token would expire after 24 hours, make sure the blobfuse volume would be remounted by your application before it expires)
+volumeAttributes.mountWithWorkloadIdentityToken (Preview) | indicates whether performing blobfuse mount with workload identity token | `true`,`false` (use the type "string" instead of "bool") | No | `false` (limitation: the workload identity token would expire after 24 hours, make sure the blobfuse volume would be remounted by your application before it expires)
 --- | **Following parameters are only for feature: blobfuse read account key or SAS token from key vault** | --- | --- |
 volumeAttributes.keyVaultURL | Azure Key Vault DNS name | existing Azure Key Vault DNS name | No |
 volumeAttributes.keyVaultSecretName | Azure Key Vault secret name | existing Azure Key Vault secret name | No |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Customer may use `bool` instead of `string` in yaml configuration and will cause the error below:
```
Error from server (BadRequest): error when creating "test.yaml": PersistentVolume in version "v1" cannot be handled as a PersistentVolume: json: cannot unmarshal bool into Go struct field CSIPersistentVolumeSource.spec.csi.volumeAttributes of type string  
```
Add a reminder will help.

This works:
```yaml
  csi:
    volumeAttributes:
      mountWithWorkloadIdentityToken: 'true'
```

This doesn't work:
```yaml
  csi:
    volumeAttributes:
      mountWithWorkloadIdentityToken: true
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
