### PR TITLE
feat: Add detection for blobfuse-proxy failures

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -155,6 +155,7 @@ const (
 	pvNameMetadata       = "${pv.metadata.name}"
 
 	VolumeID = "volumeid"
+	Protocol = "protocol"
 
 	defaultStorageEndPointSuffix = "core.windows.net"
 
@@ -383,6 +384,12 @@ func (d *Driver) Run(ctx context.Context, endpoint string) error {
 		klog.Fatalf("%v", err)
 	}
 	klog.Infof("\nDRIVER INFORMATION:\n-------------------\n%s\n\nStreaming logs below:", versionMeta)
+
+	if d.enableBlobfuseProxy && d.blobfuseProxyEndpoint != "" {
+		monitor := NewBlobfuseProxyMonitor(d.blobfuseProxyEndpoint)
+		go monitor.Start(ctx)
+	}
+
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			grpcprom.NewServerMetrics().UnaryServerInterceptor(),

--- a/pkg/blob/proxy_monitor.go
+++ b/pkg/blob/proxy_monitor.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"strings"
+	"time"
+
+	"k8s.io/klog/v2"
+	csiMetrics "sigs.k8s.io/blob-csi-driver/pkg/metrics"
+)
+
+const (
+	proxyHealthCheckInterval = 30 * time.Second
+	proxyDialTimeout         = 3 * time.Second
+)
+
+// BlobfuseProxyMonitor continuously monitors blobfuse-proxy health.
+type BlobfuseProxyMonitor struct {
+	endpoint string
+}
+
+// NewBlobfuseProxyMonitor creates a new proxy health monitor.
+func NewBlobfuseProxyMonitor(endpoint string) *BlobfuseProxyMonitor {
+	return &BlobfuseProxyMonitor{
+		endpoint: endpoint,
+	}
+}
+
+// Start begins monitoring proxy health in background.
+func (m *BlobfuseProxyMonitor) Start(ctx context.Context) {
+	// No blobfuse proxy on Windows
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	klog.V(2).Infof("Starting blobfuse-proxy health monitor for endpoint: %s", m.endpoint)
+
+	ticker := time.NewTicker(proxyHealthCheckInterval)
+	defer ticker.Stop()
+
+	m.checkHealth()
+	for {
+		select {
+		case <-ctx.Done():
+			klog.V(2).Infof("Stopping blobfuse-proxy health monitor")
+			return
+		case <-ticker.C:
+			m.checkHealth()
+		}
+	}
+}
+
+// checkHealth checks health and records metrics.
+func (m *BlobfuseProxyMonitor) checkHealth() {
+	mc := csiMetrics.NewCSIMetricContext("blobfuse_proxy_health")
+	isOperationSucceeded := m.isProxyReachable()
+	mc.Observe(isOperationSucceeded)
+}
+
+// isProxyReachable tests if it can connect to the proxy.
+func (m *BlobfuseProxyMonitor) isProxyReachable() bool {
+	network := "unix"
+	address := strings.TrimPrefix(m.endpoint, "unix://")
+	if !strings.HasPrefix(address, "/") {
+		address = "/" + address
+	}
+
+	conn, err := net.DialTimeout(network, address, proxyDialTimeout)
+	if err != nil {
+		klog.Errorf("Failed to dial blobfuse-proxy socket %s: %v", address, err)
+		return false
+	}
+	if err := conn.Close(); err != nil {
+		klog.Errorf("Failed to close blobfuse-proxy connection: %v", err)
+	}
+
+	klog.V(6).Infof("Successfully connected to blobfuse-proxy socket %s", address)
+	return true
+}

--- a/pkg/blob/proxy_monitor_test.go
+++ b/pkg/blob/proxy_monitor_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestNewBlobfuseProxyMonitor(t *testing.T) {
+	endpoint := "unix:///tmp/test-proxy.sock"
+	monitor := NewBlobfuseProxyMonitor(endpoint)
+
+	if monitor == nil {
+		t.Error("expected monitor to be created")
+	}
+
+	if monitor.endpoint != endpoint {
+		t.Errorf("expected endpoint %s, got %s", endpoint, monitor.endpoint)
+	}
+}
+
+func TestBlobfuseProxyMonitor_HealthCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
+	tempDir, err := os.MkdirTemp("", "proxy-monitor-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	socketPath := filepath.Join(tempDir, "test-proxy.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create Unix socket: %v", err)
+	}
+	defer listener.Close()
+
+	// Test successful connection
+	monitor := NewBlobfuseProxyMonitor("unix://" + socketPath)
+	if !monitor.isProxyReachable() {
+		t.Error("expected isProxyReachable to return true for valid socket")
+	}
+	// checkHealth should not panic
+	monitor.checkHealth()
+
+	// Test failed connection
+	invalidMonitor := NewBlobfuseProxyMonitor("unix:///tmp/non-existent-proxy.sock")
+	if invalidMonitor.isProxyReachable() {
+		t.Error("expected isProxyReachable to return false for non-existent socket")
+	}
+	// checkHealth should not panic even for non-existent socket
+	invalidMonitor.checkHealth()
+}
+
+func TestBlobfuseProxyMonitor_Start(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
+	monitor := NewBlobfuseProxyMonitor("unix:///tmp/test-proxy.sock")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		monitor.Start(ctx)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Expected - Start should return when context is cancelled
+	case <-time.After(200 * time.Millisecond):
+		t.Error("expected return within expected time after context cancelled")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR leverages the recently added CSI metrics for the blob csi driver to add monitoring for the blobfuse-proxy health (by attempting to connect to its Unix socket endpoint every 30 seconds) an blobfuse mount operations.

1. Blobfuse-proxy Health Monitoring: Add BlobfuseProxyMonitor to continuously monitor blobfuse-proxy health and recording successes/failures
2. Mount Operation Metrics: collect granular blobfuse mount metrics for mountBlobfuseWithProxy and mountBlobfuseInsideDriver 

**Which issue(s) this PR fixes**:

Allow for detection of blobfuse-proxy failures, especially after a node restart/upgrade.

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
