### PR TITLE
cleanup: remove obsolete blobfuse-proxy.yaml reference from kustomization.yaml

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - csi-blob-node.yaml
   - rbac-csi-blob-controller.yaml
   - rbac-csi-blob-node.yaml
-  - blobfuse-proxy.yaml


### PR DESCRIPTION
Cherry-pick of #2322 to release-1.26.

`deploy/kustomization.yaml` references `blobfuse-proxy.yaml` which no longer exists, breaking `kustomize build`.