### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/pkg/blobfuse-proxy/main.go
+++ b/pkg/blobfuse-proxy/main.go
@@ -35,6 +35,8 @@ var (
 func main() {
 	klog.InitFlags(nil)
 	_ = flag.Set("logtostderr", "true")
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false")
+	_ = flag.Set("stderrthreshold", "INFO")
 	flag.Parse()
 	proto, addr, err := csicommon.ParseEndpoint(*blobfuseProxyEndpoint)
 	if err != nil {

--- a/pkg/blobplugin/main.go
+++ b/pkg/blobplugin/main.go
@@ -52,6 +52,8 @@ var (
 func init() {
 	klog.InitFlags(nil)
 	_ = flag.Set("logtostderr", "true")
+	_ = flag.Set("legacy_stderr_threshold_behavior", "false")
+	_ = flag.Set("stderrthreshold", "INFO")
 	driverOptions.AddFlags()
 }
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When `logtostderr` is set to `true`, klog's `stderrthreshold` flag is ignored due to a legacy default behavior in klog v2. This means all log levels (including INFO and DEBUG) are written to stderr, regardless of the `stderrthreshold` setting.

This PR sets `legacy_stderr_threshold_behavior` to `false` in both `pkg/blobplugin/main.go` and `pkg/blobfuse-proxy/main.go` to opt into the corrected behavior introduced in [klog PR #432](https://github.com/kubernetes/klog/pull/432), where `stderrthreshold` is respected even when `logtostderr=true`.

## Which issue(s) this PR fixes

Fixes a logging behavior issue where `stderrthreshold` was silently ignored.

## Special notes for your reviewer

The `legacy_stderr_threshold_behavior` flag was introduced in klog v2.140.0, which is already the version used by this project. Setting it to `false` opts into the corrected behavior.

Reference: https://github.com/kubernetes/klog/pull/432

> This contribution is AI-assisted.