### PR TITLE
fix: add missing fields to storage account lockKey

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           check_filenames: true
           skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh,./pkg/lib/iscsi/
-          ignore_words_list: "AKS,aks,ro,NotIn"
+          ignore_words_list: "AKS,aks,ro,NotIn,ue"

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -1068,16 +1068,17 @@ func (d *Driver) generateSASToken(ctx context.Context, accountName, accountKey, 
 
 // serializeTags produces a deterministic string representation of a tags map
 // by sorting keys and joining as "k1=v1,k2=v2".
-// serializeTags produces a deterministic JSON string from a tags map.
-// json.Marshal sorts map keys alphabetically and escapes special characters,
-// avoiding ambiguity that hand-rolled k=v serialization would have.
+// serializeTags returns a deterministic JSON string for a tags map.
+// json.Marshal sorts map keys and escapes special characters in values.
 func serializeTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
 	}
 	b, err := json.Marshal(tags)
 	if err != nil {
-		return fmt.Sprintf("%v", tags)
+		// json.Marshal on map[string]string should never fail,
+		// but return empty string rather than non-deterministic output
+		return ""
 	}
 	return string(b)
 }

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -414,14 +414,15 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey := fmt.Sprintf("%s%s%s%s%s%s%s%s%v%v%v%v%v%v%v%s%v%d%d%s%s%s",
+			lockKey := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%s|%v|%d|%d|%s|%s|%s|%s|%v|%v|%s",
 				storageAccountType, accountKind, resourceGroup, location, protocol, subsID, accessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false),
 				ptr.Deref(requireInfraEncryption, false), ptr.Deref(allowSharedKeyAccess, true),
 				ptr.Deref(isHnsEnabled, false), ptr.Deref(enableNfsV3, false),
 				enableHTTPSTrafficOnly, publicNetworkAccess,
 				ptr.Deref(enableBlobVersioning, false), softDeleteBlobs, softDeleteContainers,
-				vnetResourceGroup, vnetName, subnetName)
+				vnetResourceGroup, vnetName, vnetLinkName, subnetName,
+				matchTags, tags, storageEndpointSuffix)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -1068,12 +1068,16 @@ func (d *Driver) generateSASToken(ctx context.Context, accountName, accountKey, 
 
 // serializeTags produces a deterministic string representation of a tags map
 // by sorting keys and joining as "k1=v1,k2=v2".
-// serializeTags produces a deterministic string representation of a tags map.
-// Uses json.Marshal which sorts keys and properly escapes values.
+// serializeTags produces a deterministic JSON string from a tags map.
+// json.Marshal sorts map keys alphabetically and escapes special characters,
+// avoiding ambiguity that hand-rolled k=v serialization would have.
 func serializeTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
 	}
-	b, _ := json.Marshal(tags)
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return fmt.Sprintf("%v", tags)
+	}
 	return string(b)
 }

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -18,11 +18,11 @@ package blob
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
-	"encoding/json"
 	"strconv"
 	"strings"
 	"time"

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"sort"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -415,7 +415,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%s|%v|%d|%d|%s|%s|%s|%s|%v|%v|%s",
+			lockKey := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%v|%v|%d|%d|%s|%s|%s|%s|%v|%v|%s",
 				storageAccountType, accountKind, resourceGroup, location, protocol, subsID, accessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false),
 				ptr.Deref(requireInfraEncryption, false), ptr.Deref(allowSharedKeyAccess, true),
@@ -1068,18 +1068,12 @@ func (d *Driver) generateSASToken(ctx context.Context, accountName, accountKey, 
 
 // serializeTags produces a deterministic string representation of a tags map
 // by sorting keys and joining as "k1=v1,k2=v2".
+// serializeTags produces a deterministic string representation of a tags map.
+// Uses json.Marshal which sorts keys and properly escapes values.
 func serializeTags(tags map[string]string) string {
 	if len(tags) == 0 {
 		return ""
 	}
-	keys := make([]string, 0, len(tags))
-	for k := range tags {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	pairs := make([]string, 0, len(tags))
-	for _, k := range keys {
-		pairs = append(pairs, k+"="+tags[k])
-	}
-	return strings.Join(pairs, ",")
+	b, _ := json.Marshal(tags)
+	return string(b)
 }

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -415,7 +415,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%v|%v|%d|%d|%s|%s|%s|%s|%v|%v|%s",
+			lockKey := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%v|%v|%v|%v|%v|%v|%d|%d|%s|%s|%s|%s|%v|%v|%s|%s",
 				storageAccountType, accountKind, resourceGroup, location, protocol, subsID, accessTier, privateDNSZoneResourceGroup,
 				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false),
 				ptr.Deref(requireInfraEncryption, false), ptr.Deref(allowSharedKeyAccess, true),
@@ -423,7 +423,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				enableHTTPSTrafficOnly, publicNetworkAccess,
 				ptr.Deref(enableBlobVersioning, false), softDeleteBlobs, softDeleteContainers,
 				vnetResourceGroup, vnetName, vnetLinkName, subnetName,
-				matchTags, serializeTags(tags), storageEndpointSuffix)
+				matchTags, serializeTags(tags), storageEndpointSuffix, srcAccountName)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -414,7 +414,14 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		if v, ok := d.volMap.Load(volName); ok {
 			accountName = v.(string)
 		} else {
-			lockKey := fmt.Sprintf("%s%s%s%s%s%s%v", storageAccountType, accountKind, resourceGroup, location, protocol, privateDNSZoneResourceGroup, ptr.Deref(createPrivateEndpoint, false))
+			lockKey := fmt.Sprintf("%s%s%s%s%s%s%s%s%v%v%v%v%v%v%v%s%v%d%d%s%s%s",
+				storageAccountType, accountKind, resourceGroup, location, protocol, subsID, accessTier, privateDNSZoneResourceGroup,
+				ptr.Deref(createPrivateEndpoint, false), ptr.Deref(allowBlobPublicAccess, false),
+				ptr.Deref(requireInfraEncryption, false), ptr.Deref(allowSharedKeyAccess, true),
+				ptr.Deref(isHnsEnabled, false), ptr.Deref(enableNfsV3, false),
+				enableHTTPSTrafficOnly, publicNetworkAccess,
+				ptr.Deref(enableBlobVersioning, false), softDeleteBlobs, softDeleteContainers,
+				vnetResourceGroup, vnetName, subnetName)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -422,7 +423,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				enableHTTPSTrafficOnly, publicNetworkAccess,
 				ptr.Deref(enableBlobVersioning, false), softDeleteBlobs, softDeleteContainers,
 				vnetResourceGroup, vnetName, vnetLinkName, subnetName,
-				matchTags, tags, storageEndpointSuffix)
+				matchTags, serializeTags(tags), storageEndpointSuffix)
 			// search in cache first
 			cache, err := d.accountSearchCache.Get(ctx, lockKey, azcache.CacheReadTypeDefault)
 			if err != nil {
@@ -1063,4 +1064,22 @@ func (d *Driver) generateSASToken(ctx context.Context, accountName, accountKey, 
 	sasToken := "?" + u.RawQuery
 	d.azcopySasTokenCache.Set(accountName, sasToken)
 	return sasToken, nil
+}
+
+// serializeTags produces a deterministic string representation of a tags map
+// by sorting keys and joining as "k1=v1,k2=v2".
+func serializeTags(tags map[string]string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, 0, len(tags))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+tags[k])
+	}
+	return strings.Join(pairs, ",")
 }

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -1066,8 +1066,6 @@ func (d *Driver) generateSASToken(ctx context.Context, accountName, accountKey, 
 	return sasToken, nil
 }
 
-// serializeTags produces a deterministic string representation of a tags map
-// by sorting keys and joining as "k1=v1,k2=v2".
 // serializeTags returns a deterministic JSON string for a tags map.
 // json.Marshal sorts map keys and escapes special characters in values.
 func serializeTags(tags map[string]string) string {

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -2157,3 +2157,58 @@ func TestGetAzcopyAuth(t *testing.T) {
 		t.Run(tc.name, tc.testFunc)
 	}
 }
+func TestSerializeTags(t *testing.T) {
+	tests := []struct {
+		desc     string
+		tags     map[string]string
+		expected string
+	}{
+		{
+			desc:     "nil map",
+			tags:     nil,
+			expected: "",
+		},
+		{
+			desc:     "empty map",
+			tags:     map[string]string{},
+			expected: "",
+		},
+		{
+			desc:     "single tag",
+			tags:     map[string]string{"key1": "value1"},
+			expected: `{"key1":"value1"}`,
+		},
+		{
+			desc:     "multiple tags sorted by key",
+			tags:     map[string]string{"beta": "2", "alpha": "1", "gamma": "3"},
+			expected: `{"alpha":"1","beta":"2","gamma":"3"}`,
+		},
+		{
+			desc:     "special characters in values",
+			tags:     map[string]string{"key": "val\"ue"},
+			expected: `{"key":"val\"ue"}`,
+		},
+		{
+			desc:     "deterministic output on repeated calls",
+			tags:     map[string]string{"z": "1", "a": "2", "m": "3"},
+			expected: `{"a":"2","m":"3","z":"1"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			result := serializeTags(test.tags)
+			if result != test.expected {
+				t.Errorf("serializeTags(%v) = %q, expected %q", test.tags, result, test.expected)
+			}
+		})
+		// verify determinism
+		if test.tags != nil {
+			first := serializeTags(test.tags)
+			second := serializeTags(test.tags)
+			if first != second {
+				t.Errorf("serializeTags not deterministic for %v: %q != %q", test.tags, first, second)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
The `lockKey` in `CreateVolume` is used to cache and reuse storage accounts across requests. Only 7 fields were included in the key, but many more `accountOptions` fields affect account properties. This causes volumes with different requirements to incorrectly share the same storage account.

### Missing fields added (15 new fields):
| Field | Impact |
|-------|--------|
| `subsID` | Different subscriptions should not share accounts |
| `accessTier` | Hot/Cool/Premium tiers differ |
| `allowBlobPublicAccess` | Public access config |
| `allowSharedKeyAccess` | Shared key access policy |
| `requireInfraEncryption` | Infrastructure encryption |
| `isHnsEnabled` | Hierarchical namespace (Data Lake) |
| `enableNfsV3` | NFS v3 protocol support |
| `enableHTTPSTrafficOnly` | Transport security |
| `publicNetworkAccess` | Network accessibility |
| `enableBlobVersioning` | Blob versioning |
| `softDeleteBlobs` | Soft delete retention days for blobs |
| `softDeleteContainers` | Soft delete retention days for containers |
| `vnetResourceGroup` | VNet resource group for private endpoint |
| `vnetName` | VNet name for private endpoint |
| `subnetName` | Subnet name for private endpoint |

## Which issue(s) this PR fixes:
None

## Requirements:
- [x] reviewed the `developer guide`
- [x] reviewed the `contributor guide`