### PR TITLE
[WIP] feat: default to kubelet identity when AzureStorageIdentityClientID is empty for MSI auth

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -754,14 +754,18 @@ func (d *Driver) GetAuthEnv(ctx context.Context, volumeID, protocol string, attr
 		authEnv = append(authEnv, "AZURE_STORAGE_SPN_TENANT_ID="+storageSPNTenantID)
 	}
 
-	if azureStorageAuthType == storageAuthTypeMSI {
-		// check whether authEnv contains AZURE_STORAGE_IDENTITY_ prefix
+	if strings.EqualFold(azureStorageAuthType, storageAuthTypeMSI) {
+		// check whether authEnv contains a non-empty AZURE_STORAGE_IDENTITY_ value
 		containsIdentityEnv := false
 		for _, env := range authEnv {
 			if strings.HasPrefix(env, "AZURE_STORAGE_IDENTITY_") {
-				klog.V(2).Infof("AZURE_STORAGE_IDENTITY_ is already set in authEnv, skip setting it again")
-				containsIdentityEnv = true
-				break
+				// skip empty values like "AZURE_STORAGE_IDENTITY_CLIENT_ID="
+				parts := strings.SplitN(env, "=", 2)
+				if len(parts) == 2 && parts[1] != "" {
+					klog.V(2).Infof("AZURE_STORAGE_IDENTITY_ is already set in authEnv, skip setting it again")
+					containsIdentityEnv = true
+					break
+				}
 			}
 		}
 		if !containsIdentityEnv {
@@ -770,7 +774,7 @@ func (d *Driver) GetAuthEnv(ctx context.Context, volumeID, protocol string, attr
 					d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID)
 				authEnv = append(authEnv, "AZURE_STORAGE_IDENTITY_CLIENT_ID="+d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID)
 			} else {
-				return rgName, accountName, accountKey, containerName, authEnv, fmt.Errorf("MSI auth is specified but no identity client ID is provided and kubelet identity is not available, please specify AzureStorageIdentityClientID")
+				klog.Warningf("MSI auth: no identity client ID provided and kubelet identity not available, MSI/IMDS will be used as fallback")
 			}
 		}
 	}

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -764,10 +764,14 @@ func (d *Driver) GetAuthEnv(ctx context.Context, volumeID, protocol string, attr
 				break
 			}
 		}
-		if !containsIdentityEnv && d.cloud != nil && d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID != "" {
-			klog.V(2).Infof("azureStorageAuthType is set to %s, add AZURE_STORAGE_IDENTITY_CLIENT_ID(%s) into authEnv",
-				azureStorageAuthType, d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID)
-			authEnv = append(authEnv, "AZURE_STORAGE_IDENTITY_CLIENT_ID="+d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID)
+		if !containsIdentityEnv {
+			if d.cloud != nil && d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID != "" {
+				klog.V(2).Infof("MSI auth: AzureStorageIdentityClientID not specified, default to kubelet identity (%s)",
+					d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID)
+				authEnv = append(authEnv, "AZURE_STORAGE_IDENTITY_CLIENT_ID="+d.cloud.Config.AzureAuthConfig.UserAssignedIdentityID)
+			} else {
+				return rgName, accountName, accountKey, containerName, authEnv, fmt.Errorf("MSI auth is specified but no identity client ID is provided and kubelet identity is not available, please specify AzureStorageIdentityClientID")
+			}
 		}
 	}
 

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2694,10 +2694,10 @@ func TestGetAuthEnvMSIDefaultsToKubeletIdentity(t *testing.T) {
 	assert.True(t, found, "Should default to kubelet identity when AzureStorageIdentityClientID is not specified")
 }
 
-func TestGetAuthEnvMSIErrorWhenNoIdentityAvailable(t *testing.T) {
+func TestGetAuthEnvMSIWarningWhenNoIdentityAvailable(t *testing.T) {
 	d := NewFakeDriver()
 	d.cloud = &storage.AccountRepo{}
-	// UserAssignedIdentityID is empty — no kubelet identity available
+	// UserAssignedIdentityID is empty — no kubelet identity available, falls back to IMDS
 
 	attrib := map[string]string{
 		containerNameField:   "containername",
@@ -2711,8 +2711,70 @@ func TestGetAuthEnvMSIErrorWhenNoIdentityAvailable(t *testing.T) {
 	volumeID := "rg#accountname#containername"
 
 	_, _, _, _, _, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret) //nolint:dogsled
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no identity client ID is provided and kubelet identity is not available")
+	assert.NoError(t, err) // should not error, falls back to IMDS
+}
+
+func TestGetAuthEnvMSIUppercase(t *testing.T) {
+	d := NewFakeDriver()
+	d.cloud = &storage.AccountRepo{}
+	d.cloud.Config.AzureAuthConfig = azclient.AzureAuthConfig{
+		UserAssignedIdentityID: "kubelet-identity-client-id",
+	}
+
+	attrib := map[string]string{
+		containerNameField:   "containername",
+		storageAccountField:  "accountname",
+		storageAuthTypeField: "MSI", // uppercase as commonly used in docs/examples
+	}
+	secret := map[string]string{
+		accountNameField: "accountname",
+		accountKeyField:  "testkey",
+	}
+	volumeID := "rg#accountname#containername"
+
+	_, _, _, _, authEnv, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret) //nolint:dogsled
+	assert.NoError(t, err)
+
+	found := false
+	for _, env := range authEnv {
+		if env == "AZURE_STORAGE_IDENTITY_CLIENT_ID=kubelet-identity-client-id" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Should default to kubelet identity even with uppercase MSI")
+}
+
+func TestGetAuthEnvMSIEmptyClientIDFallsBackToKubelet(t *testing.T) {
+	d := NewFakeDriver()
+	d.cloud = &storage.AccountRepo{}
+	d.cloud.Config.AzureAuthConfig = azclient.AzureAuthConfig{
+		UserAssignedIdentityID: "kubelet-identity-client-id",
+	}
+
+	attrib := map[string]string{
+		containerNameField:           "containername",
+		storageAccountField:          "accountname",
+		storageAuthTypeField:         storageAuthTypeMSI,
+		storageIdentityClientIDField: "", // empty value
+	}
+	secret := map[string]string{
+		accountNameField: "accountname",
+		accountKeyField:  "testkey",
+	}
+	volumeID := "rg#accountname#containername"
+
+	_, _, _, _, authEnv, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret) //nolint:dogsled
+	assert.NoError(t, err)
+
+	found := false
+	for _, env := range authEnv {
+		if env == "AZURE_STORAGE_IDENTITY_CLIENT_ID=kubelet-identity-client-id" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Empty AzureStorageIdentityClientID should fall back to kubelet identity")
 }
 
 func TestIsValidSubscriptionID(t *testing.T) {

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2663,6 +2663,58 @@ func TestGetAuthEnvMSIAuthTypeSkipsIdentityEnvIfAlreadySet(t *testing.T) {
 	assert.True(t, found, "Explicit AZURE_STORAGE_IDENTITY_CLIENT_ID should be preserved")
 }
 
+func TestGetAuthEnvMSIDefaultsToKubeletIdentity(t *testing.T) {
+	d := NewFakeDriver()
+	d.cloud = &storage.AccountRepo{}
+	d.cloud.Config.AzureAuthConfig = azclient.AzureAuthConfig{
+		UserAssignedIdentityID: "kubelet-identity-client-id",
+	}
+
+	attrib := map[string]string{
+		containerNameField:   "containername",
+		storageAccountField:  "accountname",
+		storageAuthTypeField: storageAuthTypeMSI,
+	}
+	secret := map[string]string{
+		accountNameField: "accountname",
+		accountKeyField:  "testkey",
+	}
+	volumeID := "rg#accountname#containername"
+
+	_, _, _, _, authEnv, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret) //nolint:dogsled
+	assert.NoError(t, err)
+
+	found := false
+	for _, env := range authEnv {
+		if env == "AZURE_STORAGE_IDENTITY_CLIENT_ID=kubelet-identity-client-id" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Should default to kubelet identity when AzureStorageIdentityClientID is not specified")
+}
+
+func TestGetAuthEnvMSIErrorWhenNoIdentityAvailable(t *testing.T) {
+	d := NewFakeDriver()
+	d.cloud = &storage.AccountRepo{}
+	// UserAssignedIdentityID is empty — no kubelet identity available
+
+	attrib := map[string]string{
+		containerNameField:   "containername",
+		storageAccountField:  "accountname",
+		storageAuthTypeField: storageAuthTypeMSI,
+	}
+	secret := map[string]string{
+		accountNameField: "accountname",
+		accountKeyField:  "testkey",
+	}
+	volumeID := "rg#accountname#containername"
+
+	_, _, _, _, _, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no identity client ID is provided and kubelet identity is not available")
+}
+
 func TestIsValidSubscriptionID(t *testing.T) {
 	tests := []struct {
 		desc           string

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2710,7 +2710,7 @@ func TestGetAuthEnvMSIErrorWhenNoIdentityAvailable(t *testing.T) {
 	}
 	volumeID := "rg#accountname#containername"
 
-	_, _, _, _, _, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret)
+	_, _, _, _, _, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret) //nolint:dogsled
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no identity client ID is provided and kubelet identity is not available")
 }

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2711,7 +2711,7 @@ func TestGetAuthEnvMSIWarningWhenNoIdentityAvailable(t *testing.T) {
 	volumeID := "rg#accountname#containername"
 
 	_, _, _, _, _, err := d.GetAuthEnv(context.TODO(), volumeID, "", attrib, secret) //nolint:dogsled
-	assert.NoError(t, err) // should not error, falls back to IMDS
+	assert.NoError(t, err)                                                           // should not error, falls back to IMDS
 }
 
 func TestGetAuthEnvMSIUppercase(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
When `AzureStorageAuthType` is set to `MSI` but `AzureStorageIdentityClientID` is not specified, the driver now:

1. **Defaults to the kubelet identity** (`UserAssignedIdentityID` from cloud config) — this is the built-in managed identity bound to the AKS agent node pool (named `{cluster-name}-agentpool`)
2. **Returns a clear error** if the kubelet identity is also not available, instead of silently proceeding and failing at mount time with a cryptic error

This improves the user experience for the common case where users set `AzureStorageAuthType: MSI` in their PV/StorageClass but forget to specify the identity client ID — the driver will automatically use the kubelet identity if available.

**How does this PR make you feel?**
Less cryptic mount failures 🎉

**Does this PR introduce a user-facing change?**
```release-note
When AzureStorageAuthType is set to MSI and AzureStorageIdentityClientID is not specified, the driver defaults to the kubelet identity. If no identity is available, a clear error is returned.
```