### PR TITLE
docs: improve workload identity static provisioning guide readability

### DIFF
--- a/docs/workload-identity-static-pv-mount.md
+++ b/docs/workload-identity-static-pv-mount.md
@@ -33,7 +33,7 @@ Create a [new storage account and container](https://learn.microsoft.com/en-us/a
 ```bash
 export STORAGE_RESOURCE_GROUP=<your storage account resource group>
 export ACCOUNT=<your storage account name>
-export CONTAINER=<your storage container name>  # optional for dynamic provisioning
+export CONTAINER=<your storage container name>  # required for static provisioning, optional for dynamic
 ```
 
 ### 3. Create a managed identity and assign a role
@@ -207,6 +207,7 @@ spec:
       containerName: $CONTAINER                  # required
       clientID: $USER_ASSIGNED_CLIENT_ID         # required
       resourcegroup: $STORAGE_RESOURCE_GROUP     # optional, needed if account is outside MC_ resource group
+      # mountWithWorkloadIdentityToken: "true"   # uncomment for token-only mode (Preview, v1.27.0+); requires Storage Blob Data Contributor role
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/docs/workload-identity-static-pv-mount.md
+++ b/docs/workload-identity-static-pv-mount.md
@@ -7,7 +7,7 @@
 - **NFS mount is not supported** — NFS does not require credentials during mount, so workload identity is not applicable.
 - By default, this feature retrieves the storage account key using federated identity credentials.
 - **Mount with workload identity token only (Preview):** Supported from v1.27.0. To enable:
-  - Set `mountWithWorkloadIdentityToken: "true"` in `parameters` of the StorageClass or PersistentVolume
+  - Set `mountWithWorkloadIdentityToken: "true"` in `parameters` of the StorageClass or `volumeAttributes` of the PersistentVolume
   - Grant **`Storage Blob Data Contributor`** role (instead of `Storage Account Contributor`) to the managed identity
 
 ---
@@ -45,7 +45,7 @@ export UAMI=<your managed identity name>
 az identity create --name $UAMI --resource-group $RESOURCE_GROUP
 
 export USER_ASSIGNED_CLIENT_ID="$(az identity show -g $RESOURCE_GROUP --name $UAMI --query 'clientId' -o tsv)"
-export ACCOUNT_SCOPE=$(az storage account show --name $ACCOUNT --query id -o tsv)
+export ACCOUNT_SCOPE=$(az storage account show --name $ACCOUNT --resource-group $STORAGE_RESOURCE_GROUP --query id -o tsv)
 ```
 
 Choose **one** of the following role assignments:

--- a/docs/workload-identity-static-pv-mount.md
+++ b/docs/workload-identity-static-pv-mount.md
@@ -14,14 +14,16 @@
 
 ## Prerequisites
 
-### 1. Create an AKS cluster with OIDC issuer enabled
+### 1. Create an AKS cluster with OIDC issuer enabled and get credentials
 
 Refer to the [documentation](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer#create-an-aks-cluster-with-oidc-issuer) for creating a cluster with the `--enable-oidc-issuer` parameter.
 
 ```bash
 export RESOURCE_GROUP=<your resource group name>
 export CLUSTER_NAME=<your cluster name>
-export REGION=<your region>
+
+# Get cluster credentials for kubectl
+az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME
 ```
 
 ### 2. Bring your own storage account
@@ -43,22 +45,23 @@ export UAMI=<your managed identity name>
 az identity create --name $UAMI --resource-group $RESOURCE_GROUP
 
 export USER_ASSIGNED_CLIENT_ID="$(az identity show -g $RESOURCE_GROUP --name $UAMI --query 'clientId' -o tsv)"
-export IDENTITY_TENANT=$(az aks show --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP --query identity.tenantId -o tsv)
 export ACCOUNT_SCOPE=$(az storage account show --name $ACCOUNT --query id -o tsv)
 ```
 
 Choose **one** of the following role assignments:
 
-| Option | Role | Use Case |
-|--------|------|----------|
-| **Option 1** (default) | `Storage Account Contributor` | Retrieves account key for mount |
-| **Option 2** (token-only) | `Storage Blob Data Contributor` | Mounts using workload identity token only (Preview, v1.27.0+) |
+| Mode | Role | Use Case |
+|------|------|----------|
+| **Account-key mode** (default) | `Storage Account Contributor` | Retrieves account key for mount |
+| **Token-only mode** (Preview) | `Storage Blob Data Contributor` | Mounts using workload identity token only (v1.27.0+) |
 
+**Account-key mode** (default):
 ```bash
-# Option 1: account key based (default)
 az role assignment create --role "Storage Account Contributor" --assignee $USER_ASSIGNED_CLIENT_ID --scope $ACCOUNT_SCOPE
+```
 
-# Option 2: workload identity token only (Preview)
+**Token-only mode** (Preview, v1.27.0+):
+```bash
 az role assignment create --role "Storage Blob Data Contributor" --assignee $USER_ASSIGNED_CLIENT_ID --scope $ACCOUNT_SCOPE
 ```
 
@@ -94,11 +97,13 @@ az identity federated-credential create --name $FEDERATED_IDENTITY_NAME \
 
 ---
 
-## Option 1: Dynamic Provisioning with StorageClass
+## Dynamic Provisioning with StorageClass
 
 > The CSI driver control plane identity must have the **`Storage Account Contributor`** role on the storage account (or resource group if the account is created by the driver).
 >
 > AKS cluster control plane identity is assigned this role on the node resource group by default.
+
+> **Note:** The example below uses `mountWithWorkloadIdentityToken: "true"` (token-only mode). If you chose this mode, make sure you assigned the `Storage Blob Data Contributor` role in step 3. If you prefer account-key mode (default), remove the `mountWithWorkloadIdentityToken` line.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -111,7 +116,7 @@ parameters:
   storageaccount: $ACCOUNT                    # required
   clientID: $USER_ASSIGNED_CLIENT_ID          # required (for mount auth only)
   resourcegroup: $STORAGE_RESOURCE_GROUP      # optional, needed if account is outside MC_ resource group
-  mountWithWorkloadIdentityToken: "true"      # only supported from v1.27.0
+  mountWithWorkloadIdentityToken: "true"      # token-only mode (Preview, v1.27.0+); remove for account-key mode
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
@@ -173,7 +178,7 @@ EOF
 
 ---
 
-## Option 2: Static Provisioning with PersistentVolume
+## Static Provisioning with PersistentVolume
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/docs/workload-identity-static-pv-mount.md
+++ b/docs/workload-identity-static-pv-mount.md
@@ -1,34 +1,44 @@
-# workload identity support on static provisioning
- - supported from v1.24.0 (from AKS 1.29 with `tokenRequests` field support in `CSIDriver`)
+# Workload Identity Support for Static Provisioning
 
-### Note
- - This feature is not supported for NFS mount since NFS mount does not need credentials during mount.
- - This feature would retrieve storage account key using federated identity credentials by default, you could mount with workload identity token only (**Preview**) by configuring as following:
-    > mounting with workload identity token only is supported from v1.27.0
-    - set `mountWithWorkloadIdentityToken: "true"` in `parameters` of storage class or persistent volume
-    - grant `Storage Blob Data Contributor` role instead of `Storage Account Contributor` role to the managed identity
+> Supported from v1.24.0 (AKS 1.29+ with `tokenRequests` field support in `CSIDriver`)
+
+## Important Notes
+
+- **NFS mount is not supported** — NFS does not require credentials during mount, so workload identity is not applicable.
+- By default, this feature retrieves the storage account key using federated identity credentials.
+- **Mount with workload identity token only (Preview):** Supported from v1.27.0. To enable:
+  - Set `mountWithWorkloadIdentityToken: "true"` in `parameters` of the StorageClass or PersistentVolume
+  - Grant **`Storage Blob Data Contributor`** role (instead of `Storage Account Contributor`) to the managed identity
+
+---
 
 ## Prerequisites
-### 1. Create a cluster with oidc-issuer enabled and get the AKS cluster credential
 
-Refer to the [documentation](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer#create-an-aks-cluster-with-oidc-issuer) for instructions on creating a new AKS cluster with the `--enable-oidc-issuer` parameter and get the AKS credentials. And export following environment variables:
-```console
+### 1. Create an AKS cluster with OIDC issuer enabled
+
+Refer to the [documentation](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer#create-an-aks-cluster-with-oidc-issuer) for creating a cluster with the `--enable-oidc-issuer` parameter.
+
+```bash
 export RESOURCE_GROUP=<your resource group name>
 export CLUSTER_NAME=<your cluster name>
 export REGION=<your region>
 ```
 
 ### 2. Bring your own storage account
-Refer to the [documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-cli) for instructions on creating a new storage account and container, or alternatively, utilize your existing storage account and container. And export following environment variables:
-```console
+
+Create a [new storage account and container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-cli), or use an existing one.
+
+```bash
 export STORAGE_RESOURCE_GROUP=<your storage account resource group>
 export ACCOUNT=<your storage account name>
-export CONTAINER=<your storage container name> # optional
+export CONTAINER=<your storage container name>  # optional for dynamic provisioning
 ```
 
-### 3. Create or bring your own managed identity and grant role to the managed identity
-> you could leverage the built-in user assigned managed identity bound to the AKS agent node pool(with name [`AKS Cluster Name-agentpool`](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities)) in node resource group
-```console
+### 3. Create a managed identity and assign a role
+
+> **Tip:** You can use the built-in kubelet identity bound to the AKS agent node pool (named [`{AKS-Cluster-Name}-agentpool`](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#summary-of-managed-identities)) in the node resource group.
+
+```bash
 export UAMI=<your managed identity name>
 az identity create --name $UAMI --resource-group $RESOURCE_GROUP
 
@@ -36,18 +46,25 @@ export USER_ASSIGNED_CLIENT_ID="$(az identity show -g $RESOURCE_GROUP --name $UA
 export IDENTITY_TENANT=$(az aks show --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP --query identity.tenantId -o tsv)
 export ACCOUNT_SCOPE=$(az storage account show --name $ACCOUNT --query id -o tsv)
 ```
- - option#1: grant `Storage Account Contributor` role to the managed identity to retrieve account key (default)
-```console
-az role assignment create --role "Storage Account Contributor" --assignee $USER_ASSIGNED_CLIENT_ID --scope $ACCOUNT_SCOPE
-```
 
- - option#2: grant the `Storage Blob Data Contributor` role to the managed identity for mounting using a workload identity token exclusively, without relying on account key authentication.
-```console
+Choose **one** of the following role assignments:
+
+| Option | Role | Use Case |
+|--------|------|----------|
+| **Option 1** (default) | `Storage Account Contributor` | Retrieves account key for mount |
+| **Option 2** (token-only) | `Storage Blob Data Contributor` | Mounts using workload identity token only (Preview, v1.27.0+) |
+
+```bash
+# Option 1: account key based (default)
+az role assignment create --role "Storage Account Contributor" --assignee $USER_ASSIGNED_CLIENT_ID --scope $ACCOUNT_SCOPE
+
+# Option 2: workload identity token only (Preview)
 az role assignment create --role "Storage Blob Data Contributor" --assignee $USER_ASSIGNED_CLIENT_ID --scope $ACCOUNT_SCOPE
 ```
 
-### 4. Create a service account on AKS
-```
+### 4. Create a Kubernetes service account
+
+```bash
 export SERVICE_ACCOUNT_NAME=<your sa name>
 export SERVICE_ACCOUNT_NAMESPACE=<your sa namespace>
 
@@ -60,23 +77,28 @@ metadata:
 EOF
 ```
 
-### 5. Create the federated identity credential between the managed identity, service account issuer, and subject using the `az identity federated-credential create` command.
-```
+### 5. Create the federated identity credential
+
+Link the managed identity, OIDC issuer, and service account:
+
+```bash
 export FEDERATED_IDENTITY_NAME=<your federated identity name>
 export AKS_OIDC_ISSUER="$(az aks show --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME --query "oidcIssuerProfile.issuerUrl" -o tsv)"
 
 az identity federated-credential create --name $FEDERATED_IDENTITY_NAME \
---identity-name $UAMI \
---resource-group $RESOURCE_GROUP \
---issuer $AKS_OIDC_ISSUER \
---subject system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}
+  --identity-name $UAMI \
+  --resource-group $RESOURCE_GROUP \
+  --issuer $AKS_OIDC_ISSUER \
+  --subject system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}
 ```
 
-## option#1: dynamic provisioning with storage class
-- Ensure that the identity of your CSI driver control plane is assigned the `Storage Account Contributor role` for the storage account.
- > if the storage account is created by the driver, then you need to grant `Storage Account Contributor` role to the resource group where the storage account is located.
- > 
- > AKS cluster control plane identity is assigned the `Storage Account Contributor role` on the node resource group for the storage account by default.
+---
+
+## Option 1: Dynamic Provisioning with StorageClass
+
+> The CSI driver control plane identity must have the **`Storage Account Contributor`** role on the storage account (or resource group if the account is created by the driver).
+>
+> AKS cluster control plane identity is assigned this role on the node resource group by default.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -86,10 +108,10 @@ metadata:
   name: blob-fuse-wi
 provisioner: blob.csi.azure.com
 parameters:
-  storageaccount: $ACCOUNT # required
-  clientID: $USER_ASSIGNED_CLIENT_ID # required, $USER_ASSIGNED_CLIENT_ID is only for mount auth, make sure you CSI driver controller pod has `Contributor` role on the specified account
-  resourcegroup: $STORAGE_RESOURCE_GROUP # optional, specified when the storage account is not under AKS node resource group(which is prefixed with "MC_")
-  mountWithWorkloadIdentityToken: "true" # only supported from CSI driver v1.27.0
+  storageaccount: $ACCOUNT                    # required
+  clientID: $USER_ASSIGNED_CLIENT_ID          # required (for mount auth only)
+  resourcegroup: $STORAGE_RESOURCE_GROUP      # optional, needed if account is outside MC_ resource group
+  mountWithWorkloadIdentityToken: "true"      # only supported from v1.27.0
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
@@ -97,12 +119,12 @@ mountOptions:
   - -o allow_other
   - --file-cache-timeout-in-seconds=120
   - --use-attr-cache=true
-  - --cancel-list-on-mount-seconds=10  # prevent billing charges on mounting
+  - --cancel-list-on-mount-seconds=10         # prevent billing charges on mounting
   - -o attr_timeout=120
   - -o entry_timeout=120
   - -o negative_timeout=120
-  - --log-level=LOG_WARNING  # LOG_WARNING, LOG_INFO, LOG_DEBUG
-  - --cache-size-mb=1000  # Default will be 80% of available memory, eviction will happen beyond that.
+  - --log-level=LOG_WARNING                   # LOG_WARNING, LOG_INFO, LOG_DEBUG
+  - --cache-size-mb=1000                      # default is 80% of available memory
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -114,14 +136,17 @@ metadata:
 spec:
   serviceName: statefulset-blob
   replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:
         app: nginx
     spec:
-      serviceAccountName: $SERVICE_ACCOUNT_NAME  #required, make sure the pod have the required permissions to mount volume
+      serviceAccountName: $SERVICE_ACCOUNT_NAME   # required for workload identity
       nodeSelector:
-        "kubernetes.io/os": linux
+        kubernetes.io/os: linux
       containers:
         - name: statefulset-blob
           image: mcr.microsoft.com/mirror/docker/library/nginx:1.23
@@ -134,9 +159,6 @@ spec:
               mountPath: /mnt/blob
   updateStrategy:
     type: RollingUpdate
-  selector:
-    matchLabels:
-      app: nginx
   volumeClaimTemplates:
     - metadata:
         name: persistent-storage
@@ -149,7 +171,10 @@ spec:
 EOF
 ```
 
-## option#2: static provision with PV
+---
+
+## Option 2: Static Provisioning with PersistentVolume
+
 ```yaml
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
@@ -173,10 +198,10 @@ spec:
     # make sure volumeHandle is unique for every storage blob container in the cluster
     volumeHandle: "{resource-group-name}#{account-name}#{container-name}"
     volumeAttributes:
-      storageaccount: $ACCOUNT # required
-      containerName: $CONTAINER  # required
-      clientID: $USER_ASSIGNED_CLIENT_ID # required
-      resourcegroup: $STORAGE_RESOURCE_GROUP # optional, specified when the storage account is not under AKS node resource group(which is prefixed with "MC_")
+      storageaccount: $ACCOUNT                   # required
+      containerName: $CONTAINER                  # required
+      clientID: $USER_ASSIGNED_CLIENT_ID         # required
+      resourcegroup: $STORAGE_RESOURCE_GROUP     # optional, needed if account is outside MC_ resource group
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -195,10 +220,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: nginx
   name: deployment-blob
   namespace: ${SERVICE_ACCOUNT_NAMESPACE}
+  labels:
+    app: nginx
 spec:
   replicas: 1
   selector:
@@ -208,11 +233,10 @@ spec:
     metadata:
       labels:
         app: nginx
-      name: deployment-blob
     spec:
-      serviceAccountName: $SERVICE_ACCOUNT_NAME  #required, Pod lacks the necessary permission to mount the volume without this field
+      serviceAccountName: $SERVICE_ACCOUNT_NAME   # required for workload identity
       nodeSelector:
-        "kubernetes.io/os": linux
+        kubernetes.io/os: linux
       containers:
         - name: deployment-blob
           image: mcr.microsoft.com/oss/nginx/nginx:1.17.3-alpine
@@ -222,7 +246,7 @@ spec:
             - while true; do echo $(date) >> /mnt/blob/outfile; sleep 1; done
           volumeMounts:
             - name: blob
-              mountPath: "/mnt/blob"
+              mountPath: /mnt/blob
       volumes:
         - name: blob
           persistentVolumeClaim:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**
Restructures and improves the readability of the workload identity static provisioning guide:

- **Clearer title and section headers** — proper heading hierarchy with `---` separators
- **Role assignment comparison table** — side-by-side comparison of Option 1 (account key) vs Option 2 (token-only)
- **Consistent formatting** — unified `bash` code blocks, aligned YAML comments, proper indentation
- **Better notes section** — key caveats (NFS, token-only preview) moved to a prominent "Important Notes" section at the top
- **Improved inline comments** — YAML fields annotated with `# required` / `# optional` for quick scanning
- **Removed redundancy** — consolidated repeated instructions

No functional changes — documentation only.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```