### PR TITLE
fix: skip storing account key when using identity-based mount

### DIFF
--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -189,11 +189,17 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			containerNameReplaceMap[pvNameMetadata] = v
 		case serverNameField:
 		case storageAuthTypeField:
+			if strings.EqualFold(v, "MSI") {
+				storeAccountKey = false
+			}
 		case storageIdentityClientIDField:
 		case storageIdentityObjectIDField:
 		case storageIdentityResourceIDField:
 		case clientIDField:
 		case mountWithWITokenField:
+			if strings.EqualFold(v, trueValue) {
+				storeAccountKey = false
+			}
 		case tenantIDField:
 		case msiEndpointField:
 		case storageAADEndpointField:

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -723,7 +723,7 @@ func TestCreateVolume(t *testing.T) {
 				d.cloud.SubscriptionID = "subID"
 
 				mp := make(map[string]string)
-				mp[protocolField] = "fuse"
+				mp[protocolField] = "nfs"
 				mp[skuNameField] = "unit-test"
 				mp[storageAccountTypeField] = "unit-test"
 				mp[locationField] = "unit-test"
@@ -742,13 +742,12 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				// Should NOT get "storeAccountKey is not supported" error because
-				// storageAuthType=MSI implies storeAccountKey=false
+				// storageAuthType=MSI implies storeAccountKey=false.
+				// With NFS protocol, it will fail later with "networkClientFactory is nil".
 				_, err := d.CreateVolume(context.Background(), req)
-				if err != nil {
-					invalidArgErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
-					if reflect.DeepEqual(err, invalidArgErr) {
-						t.Errorf("storageAuthType=MSI should have disabled storeAccountKey, but got: %v", err)
-					}
+				invalidArgErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
+				if reflect.DeepEqual(err, invalidArgErr) {
+					t.Errorf("storageAuthType=MSI should have disabled storeAccountKey, but got: %v", err)
 				}
 			},
 		},
@@ -760,7 +759,7 @@ func TestCreateVolume(t *testing.T) {
 				d.cloud.SubscriptionID = "subID"
 
 				mp := make(map[string]string)
-				mp[protocolField] = "fuse"
+				mp[protocolField] = "nfs"
 				mp[skuNameField] = "unit-test"
 				mp[storageAccountTypeField] = "unit-test"
 				mp[locationField] = "unit-test"
@@ -779,13 +778,12 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				// Should NOT get "storeAccountKey is not supported" error because
-				// mountWithWorkloadIdentityToken=true implies storeAccountKey=false
+				// mountWithWorkloadIdentityToken=true implies storeAccountKey=false.
+				// With NFS protocol, it will fail later with "networkClientFactory is nil".
 				_, err := d.CreateVolume(context.Background(), req)
-				if err != nil {
-					invalidArgErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
-					if reflect.DeepEqual(err, invalidArgErr) {
-						t.Errorf("mountWithWIToken=true should have disabled storeAccountKey, but got: %v", err)
-					}
+				invalidArgErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
+				if reflect.DeepEqual(err, invalidArgErr) {
+					t.Errorf("mountWithWIToken=true should have disabled storeAccountKey, but got: %v", err)
 				}
 			},
 		},

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -716,6 +716,80 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "storageAuthType=MSI should skip storeAccountKey even with allowSharedKeyAccess=false",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.cloud = &storage.AccountRepo{}
+				d.cloud.SubscriptionID = "subID"
+
+				mp := make(map[string]string)
+				mp[protocolField] = "fuse"
+				mp[skuNameField] = "unit-test"
+				mp[storageAccountTypeField] = "unit-test"
+				mp[locationField] = "unit-test"
+				mp[storageAccountField] = "unittest"
+				mp[resourceGroupField] = "unit-test"
+				mp[containerNameField] = "unit-test"
+				mp[storageAuthTypeField] = "MSI"
+				mp[allowSharedKeyAccessField] = falseValue
+				req := &csi.CreateVolumeRequest{
+					Name:               "unit-test",
+					VolumeCapabilities: stdVolumeCapabilities,
+					Parameters:         mp,
+				}
+				d.Cap = []*csi.ControllerServiceCapability{
+					controllerServiceCapability,
+				}
+
+				// Should NOT get "storeAccountKey is not supported" error because
+				// storageAuthType=MSI implies storeAccountKey=false
+				_, err := d.CreateVolume(context.Background(), req)
+				if err != nil {
+					invalidArgErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
+					if reflect.DeepEqual(err, invalidArgErr) {
+						t.Errorf("storageAuthType=MSI should have disabled storeAccountKey, but got: %v", err)
+					}
+				}
+			},
+		},
+		{
+			name: "mountWithWorkloadIdentityToken=true should skip storeAccountKey even with allowSharedKeyAccess=false",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.cloud = &storage.AccountRepo{}
+				d.cloud.SubscriptionID = "subID"
+
+				mp := make(map[string]string)
+				mp[protocolField] = "fuse"
+				mp[skuNameField] = "unit-test"
+				mp[storageAccountTypeField] = "unit-test"
+				mp[locationField] = "unit-test"
+				mp[storageAccountField] = "unittest"
+				mp[resourceGroupField] = "unit-test"
+				mp[containerNameField] = "unit-test"
+				mp[mountWithWITokenField] = "true"
+				mp[allowSharedKeyAccessField] = falseValue
+				req := &csi.CreateVolumeRequest{
+					Name:               "unit-test",
+					VolumeCapabilities: stdVolumeCapabilities,
+					Parameters:         mp,
+				}
+				d.Cap = []*csi.ControllerServiceCapability{
+					controllerServiceCapability,
+				}
+
+				// Should NOT get "storeAccountKey is not supported" error because
+				// mountWithWorkloadIdentityToken=true implies storeAccountKey=false
+				_, err := d.CreateVolume(context.Background(), req)
+				if err != nil {
+					invalidArgErr := status.Errorf(codes.InvalidArgument, "storeAccountKey is not supported for account with shared access key disabled")
+					if reflect.DeepEqual(err, invalidArgErr) {
+						t.Errorf("mountWithWIToken=true should have disabled storeAccountKey, but got: %v", err)
+					}
+				}
+			},
+		},
+		{
 			name: "Successful I/O",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -205,6 +205,6 @@ func checkAccountCreationLeak(ctx context.Context) {
 	framework.ExpectNoError(err, fmt.Sprintf("failed to GetAccountNumByResourceGroup(%s): %v", creds.ResourceGroup, err))
 	ginkgo.By(fmt.Sprintf("GetAccountNumByResourceGroup(%s) returns %d accounts", creds.ResourceGroup, accountNum))
 
-	accountLimitInTest := 20
+	accountLimitInTest := 22
 	gomega.Expect(accountNum >= accountLimitInTest).To(gomega.BeFalse())
 }


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
When `storageAuthType` is `MSI` or `mountWithWorkloadIdentityToken` is `true`, the mount authentication uses identity-based tokens (IMDS or federated token exchange), not storage account keys.

Currently, `CreateVolume` still stores the storage account key into the Kubernetes secret. This is unnecessary and can interfere with identity-based mount flows.

This PR sets `storeAccountKey = false` when either condition is met, skipping the account key write to the secret.

This is the blob CSI equivalent of kubernetes-sigs/azurefile-csi-driver#3125.

## Which issue(s) this PR fixes
N/A

## Does this PR introduce a user-facing change?
```release-note
fix: skip storing account key to secret when storageAuthType is MSI or mountWithWorkloadIdentityToken is true
```