### PR TITLE
test: add managed identity auth mount e2e test for dynamic provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
@@ -50,8 +52,6 @@ require (
 	cel.dev/expr v0.25.1 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0 // indirect

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/blob-csi-driver/test/e2e/testsuites"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1149,8 +1149,12 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for CAPZ test")
 		}
-		gomega.Expect(miRoleSetupSucceeded).To(gomega.BeTrue(), "MI role assignment failed, cannot run managed identity auth mount test")
-		gomega.Expect(miClientID).NotTo(gomega.BeEmpty(), "MI client ID is empty, cannot run managed identity auth mount test")
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for capz test")
+		}
+		if !miRoleSetupSucceeded || miClientID == "" {
+			ginkgo.Skip("MI role setup did not succeed or client ID is empty, skipping managed identity auth mount test")
+		}
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1171,10 +1171,10 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			},
 		}
 		scParameters := map[string]string{
-			"skuName":                       "Premium_LRS",
-			"protocol":                      "fuse",
-			"AzureStorageAuthType":          "MSI",
-			"AzureStorageIdentityClientID":  miClientID,
+			"skuName":                      "Premium_LRS",
+			"protocol":                     "fuse",
+			"AzureStorageAuthType":         "MSI",
+			"AzureStorageIdentityClientID": miClientID,
 		}
 		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
 			CSIDriver:              testDriver,

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -22,8 +22,11 @@ import (
 
 	"sigs.k8s.io/blob-csi-driver/test/e2e/driver"
 	"sigs.k8s.io/blob-csi-driver/test/e2e/testsuites"
+	"sigs.k8s.io/blob-csi-driver/test/utils/azure"
+	"sigs.k8s.io/blob-csi-driver/test/utils/credentials"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -1148,9 +1151,13 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for CAPZ test")
 		}
-		if !miRoleSetupSucceeded || miClientID == "" {
-			ginkgo.Skip("MI role setup did not succeed or client ID is empty, skipping managed identity auth mount test")
-		}
+		creds, err := credentials.CreateAzureCredentialFile()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		azureClient, err := azure.GetClient(creds.Cloud, creds.SubscriptionID, creds.AADClientID, creds.TenantID, creds.AADClientSecret, creds.AADFederatedTokenFile)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		miClientID, err := azureClient.EnsureNodeStorageBlobDataRole(ctx, creds.ResourceGroup)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to assign Storage Blob Data Contributor role to node identity")
+		gomega.Expect(miClientID).NotTo(gomega.BeEmpty(), "no user-assigned identity client ID found")
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/blob-csi-driver/test/e2e/testsuites"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -1140,6 +1141,45 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 				"skuName":  "Premium_LRS",
 				"protocol": "fuse2",
 			},
+		}
+		test.Run(ctx, cs, ns)
+	})
+
+	ginkgo.It("should create a volume on demand with managed identity auth mount [blob.csi.azure.com]", func(ctx ginkgo.SpecContext) {
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for CAPZ test")
+		}
+		gomega.Expect(miRoleSetupSucceeded).To(gomega.BeTrue(), "MI role assignment failed, cannot run managed identity auth mount test")
+		gomega.Expect(miClientID).NotTo(gomega.BeEmpty(), "MI client ID is empty, cannot run managed identity auth mount test")
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"-o allow_other",
+							"--file-cache-timeout-in-seconds=120",
+							"--cancel-list-on-mount-seconds=0",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		scParameters := map[string]string{
+			"skuName":                       "Premium_LRS",
+			"protocol":                      "fuse",
+			"AzureStorageAuthType":          "MSI",
+			"AzureStorageIdentityClientID":  miClientID,
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: scParameters,
 		}
 		test.Run(ctx, cs, ns)
 	})

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1148,9 +1148,6 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		if !isCapzTest {
 			ginkgo.Skip("test case is only available for CAPZ test")
 		}
-		if !isCapzTest {
-			ginkgo.Skip("test case is only available for capz test")
-		}
 		if !miRoleSetupSucceeded || miClientID == "" {
 			ginkgo.Skip("MI role setup did not succeed or client ID is empty, skipping managed identity auth mount test")
 		}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -50,8 +50,11 @@ const (
 )
 
 var isAzureStackCloud = strings.EqualFold(os.Getenv("AZURE_CLOUD_NAME"), "AZURESTACKCLOUD")
+var isCapzTest = os.Getenv("NODE_MACHINE_TYPE") != ""
 var blobDriver *blob.Driver
 var projectRoot string
+var miRoleSetupSucceeded bool
+var miClientID string
 
 type testCmd struct {
 	command  string
@@ -92,6 +95,19 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	_, err = azureClient.EnsureResourceGroup(ctx, creds.ResourceGroup, creds.Location, nil)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Assign Storage Blob Data Contributor role to node identities
+	// This is required for managed identity auth mount e2e tests (CAPZ only)
+	if isCapzTest {
+		clientID, err := azureClient.EnsureNodeStorageBlobDataRole(ctx, creds.ResourceGroup)
+		if err != nil {
+			log.Printf("WARNING: failed to assign Storage Blob Data Contributor role to node identity: %v", err)
+		} else {
+			miRoleSetupSucceeded = true
+			miClientID = clientID
+			log.Printf("MI role setup succeeded, clientID=%s", clientID)
+		}
+	}
 
 	// Install Azure Blob Storage CSI driver on cluster from project root
 	e2eBootstrap := testCmd{

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -53,8 +53,6 @@ var isAzureStackCloud = strings.EqualFold(os.Getenv("AZURE_CLOUD_NAME"), "AZURES
 var isCapzTest = os.Getenv("NODE_MACHINE_TYPE") != "" || os.Getenv("AZURE_NODE_MACHINE_TYPE") != ""
 var blobDriver *blob.Driver
 var projectRoot string
-var miRoleSetupSucceeded bool
-var miClientID string
 
 type testCmd struct {
 	command  string
@@ -96,23 +94,6 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 	_, err = azureClient.EnsureResourceGroup(ctx, creds.ResourceGroup, creds.Location, nil)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Assign Storage Blob Data Contributor role to node identities
-	// This is required for managed identity auth mount e2e tests (CAPZ only)
-	if isCapzTest {
-		clientID, err := azureClient.EnsureNodeStorageBlobDataRole(ctx, creds.ResourceGroup)
-		if err != nil {
-			log.Printf("WARNING: failed to assign Storage Blob Data Contributor role to node identity: %v", err)
-		} else if clientID == "" {
-			log.Printf("WARNING: MI role assignment succeeded but no usable client ID was found")
-		} else {
-			miRoleSetupSucceeded = true
-			miClientID = clientID
-			log.Printf("MI role setup succeeded, clientID=%s. Waiting 60s for RBAC propagation ...", clientID)
-			time.Sleep(60 * time.Second)
-			log.Printf("RBAC propagation wait complete")
-		}
-	}
-
 	// Install Azure Blob Storage CSI driver on cluster from project root
 	e2eBootstrap := testCmd{
 		command:  "make",
@@ -128,21 +109,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 		endLog:   "metrics service created",
 	}
 	execTestCmd([]testCmd{e2eBootstrap, createMetricsSVC})
-
-	// Pass MI setup result to all Ginkgo processes via the data channel
-	// Format: "ok:<clientID>" on success, empty on failure/skip
-	var miData string
-	if miRoleSetupSucceeded {
-		miData = "ok:" + miClientID
-	}
-	return []byte(miData)
-}, func(_ ginkgo.SpecContext, data []byte) {
-	// Receive MI setup result from process 1
-	if s := string(data); strings.HasPrefix(s, "ok:") {
-		miClientID = strings.TrimPrefix(s, "ok:")
-		miRoleSetupSucceeded = true
-		log.Printf("Received MI client ID from process 1: %s", miClientID)
-	}
+	return nil
+}, func(_ ginkgo.SpecContext, _ []byte) {
 	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
 	// it does not fall back to defaults
 	if os.Getenv(kubeconfigEnvVar) == "" {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -50,7 +50,7 @@ const (
 )
 
 var isAzureStackCloud = strings.EqualFold(os.Getenv("AZURE_CLOUD_NAME"), "AZURESTACKCLOUD")
-var isCapzTest = os.Getenv("NODE_MACHINE_TYPE") != ""
+var isCapzTest = os.Getenv("NODE_MACHINE_TYPE") != "" || os.Getenv("AZURE_NODE_MACHINE_TYPE") != ""
 var blobDriver *blob.Driver
 var projectRoot string
 var miRoleSetupSucceeded bool

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -107,7 +107,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 		} else {
 			miRoleSetupSucceeded = true
 			miClientID = clientID
-			log.Printf("MI role setup succeeded, clientID=%s", clientID)
+			log.Printf("MI role setup succeeded, clientID=%s. Waiting 60s for RBAC propagation ...", clientID)
+			time.Sleep(60 * time.Second)
+			log.Printf("RBAC propagation wait complete")
 		}
 	}
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -124,8 +124,16 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 		endLog:   "metrics service created",
 	}
 	execTestCmd([]testCmd{e2eBootstrap, createMetricsSVC})
-	return nil
-}, func(_ ginkgo.SpecContext, _ []byte) {
+
+	// Pass MI client ID to all Ginkgo processes via the data channel
+	return []byte(miClientID)
+}, func(_ ginkgo.SpecContext, data []byte) {
+	// Receive MI client ID from process 1
+	if len(data) > 0 {
+		miClientID = string(data)
+		miRoleSetupSucceeded = true
+		log.Printf("Received MI client ID from process 1: %s", miClientID)
+	}
 	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
 	// it does not fall back to defaults
 	if os.Getenv(kubeconfigEnvVar) == "" {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -102,6 +102,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 		clientID, err := azureClient.EnsureNodeStorageBlobDataRole(ctx, creds.ResourceGroup)
 		if err != nil {
 			log.Printf("WARNING: failed to assign Storage Blob Data Contributor role to node identity: %v", err)
+		} else if clientID == "" {
+			log.Printf("WARNING: MI role assignment succeeded but no usable client ID was found")
 		} else {
 			miRoleSetupSucceeded = true
 			miClientID = clientID
@@ -125,12 +127,17 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 	}
 	execTestCmd([]testCmd{e2eBootstrap, createMetricsSVC})
 
-	// Pass MI client ID to all Ginkgo processes via the data channel
-	return []byte(miClientID)
+	// Pass MI setup result to all Ginkgo processes via the data channel
+	// Format: "ok:<clientID>" on success, empty on failure/skip
+	var miData string
+	if miRoleSetupSucceeded {
+		miData = "ok:" + miClientID
+	}
+	return []byte(miData)
 }, func(_ ginkgo.SpecContext, data []byte) {
-	// Receive MI client ID from process 1
-	if len(data) > 0 {
-		miClientID = string(data)
+	// Receive MI setup result from process 1
+	if s := string(data); strings.HasPrefix(s, "ok:") {
+		miClientID = strings.TrimPrefix(s, "ok:")
 		miRoleSetupSucceeded = true
 		log.Printf("Received MI client ID from process 1: %s", miClientID)
 	}

--- a/test/utils/azure/azure_helper.go
+++ b/test/utils/azure/azure_helper.go
@@ -326,10 +326,9 @@ func (az *Client) EnsureNodeStorageBlobDataRole(ctx context.Context, resourceGro
 		}
 	}
 	if firstClientID == "" {
-		err := fmt.Errorf("successfully assigned Storage Blob Data Contributor role to %d node identities in resource group %s, but no usable node identity client ID was found", len(identities), resourceGroup)
-		log.Printf("%v", err)
-		return "", err
+		log.Printf("WARNING: assigned Storage Blob Data Contributor role to %d node identities in resource group %s, but no user-assigned identity client ID was found (system-assigned MI may still work)", len(identities), resourceGroup)
+	} else {
+		log.Printf("Successfully assigned Storage Blob Data Contributor role to all %d node identities and found client ID %s", len(identities), firstClientID)
 	}
-	log.Printf("Successfully assigned Storage Blob Data Contributor role to all %d node identities and found client ID %s", len(identities), firstClientID)
 	return firstClientID, nil
 }

--- a/test/utils/azure/azure_helper.go
+++ b/test/utils/azure/azure_helper.go
@@ -179,8 +179,8 @@ type NodeIdentityInfo struct {
 	ClientID    string
 }
 
-// GetNodeIdentityInfo retrieves the principal IDs and client IDs of managed identities from VMSS and VMs in the resource group.
-// Returns the first user-assigned identity's client ID for use in e2e tests.
+// GetNodeIdentityInfo retrieves managed identity information from VMSS and VMs in the resource group.
+// It returns a slice of NodeIdentityInfo containing principal IDs and client IDs where available.
 func (az *Client) GetNodeIdentityInfo(ctx context.Context, resourceGroup string) ([]NodeIdentityInfo, error) {
 	var identities []NodeIdentityInfo
 
@@ -325,6 +325,11 @@ func (az *Client) EnsureNodeStorageBlobDataRole(ctx context.Context, resourceGro
 			firstClientID = identity.ClientID
 		}
 	}
-	log.Printf("Successfully assigned Storage Blob Data Contributor role to all %d node identities", len(identities))
+	if firstClientID == "" {
+		err := fmt.Errorf("successfully assigned Storage Blob Data Contributor role to %d node identities in resource group %s, but no usable node identity client ID was found", len(identities), resourceGroup)
+		log.Printf("%v", err)
+		return "", err
+	}
+	log.Printf("Successfully assigned Storage Blob Data Contributor role to all %d node identities and found client ID %s", len(identities), firstClientID)
 	return firstClientID, nil
 }

--- a/test/utils/azure/azure_helper.go
+++ b/test/utils/azure/azure_helper.go
@@ -18,12 +18,19 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
+	"net/http"
 	"os"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	resources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/google/uuid"
 	"sigs.k8s.io/blob-csi-driver/pkg/blob"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/accountclient"
@@ -42,6 +49,9 @@ type Client struct {
 	roleassignmentClient roleassignmentclient.Interface
 	vaultClient          vaultclient.Interface
 	identityClient       identityclient.Interface
+	vmssClient           *armcompute.VirtualMachineScaleSetsClient
+	vmClient             *armcompute.VirtualMachinesClient
+	roleClient           *armauthorization.RoleAssignmentsClient
 }
 
 func GetClient(cloud, subscriptionID, clientID, tenantID, clientSecret string, aadFederatedTokenFile string) (*Client, error) {
@@ -78,6 +88,26 @@ func GetClient(cloud, subscriptionID, clientID, tenantID, clientSecret string, a
 	if err != nil {
 		return nil, err
 	}
+
+	armClientOpts, err := azclient.GetDefaultResourceClientOption(armConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default ARM client options: %v", err)
+	}
+	armClientOpts.Cloud = clientOps
+
+	vmssClient, err := armcompute.NewVirtualMachineScaleSetsClient(subscriptionID, cred, armClientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VMSS client: %v", err)
+	}
+	vmClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, cred, armClientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VM client: %v", err)
+	}
+	roleAssignClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, armClientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role assignments client: %v", err)
+	}
+
 	return &Client{
 		subscriptionID:       subscriptionID,
 		groupsClient:         factory.GetResourceGroupClient(),
@@ -86,6 +116,9 @@ func GetClient(cloud, subscriptionID, clientID, tenantID, clientSecret string, a
 		vaultClient:          factory.GetVaultClient(),
 		roledefinitionClient: roleclient,
 		identityClient:       factory.GetIdentityClient(),
+		vmssClient:           vmssClient,
+		vmClient:             vmClient,
+		roleClient:           roleAssignClient,
 	}, nil
 }
 
@@ -138,4 +171,160 @@ func (az *Client) GetAccountNumByResourceGroup(ctx context.Context, groupName st
 		return -1, err
 	}
 	return len(result), nil
+}
+
+// NodeIdentityInfo holds the principal ID and client ID of a managed identity.
+type NodeIdentityInfo struct {
+	PrincipalID string
+	ClientID    string
+}
+
+// GetNodeIdentityInfo retrieves the principal IDs and client IDs of managed identities from VMSS and VMs in the resource group.
+// Returns the first user-assigned identity's client ID for use in e2e tests.
+func (az *Client) GetNodeIdentityInfo(ctx context.Context, resourceGroup string) ([]NodeIdentityInfo, error) {
+	var identities []NodeIdentityInfo
+
+	// Check VMSS
+	log.Printf("Listing VMSS in resource group %s ...", resourceGroup)
+	vmssPager := az.vmssClient.NewListPager(resourceGroup, nil)
+	for vmssPager.More() {
+		page, err := vmssPager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VMSS in resource group %s: %v", resourceGroup, err)
+		}
+		for _, vmss := range page.Value {
+			name := ""
+			if vmss.Name != nil {
+				name = *vmss.Name
+			}
+			if vmss.Identity == nil {
+				log.Printf("VMSS %s has no managed identity, skipping", name)
+				continue
+			}
+			// System-assigned identity
+			if vmss.Identity.PrincipalID != nil && *vmss.Identity.PrincipalID != "" {
+				log.Printf("VMSS %s: found system-assigned identity, principalID=%s", name, *vmss.Identity.PrincipalID)
+				identities = append(identities, NodeIdentityInfo{PrincipalID: *vmss.Identity.PrincipalID})
+			}
+			// User-assigned identities
+			for uaID, uaIdentity := range vmss.Identity.UserAssignedIdentities {
+				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
+					clientID := ""
+					if uaIdentity.ClientID != nil {
+						clientID = *uaIdentity.ClientID
+					}
+					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s, clientID=%s", name, uaID, *uaIdentity.PrincipalID, clientID)
+					identities = append(identities, NodeIdentityInfo{PrincipalID: *uaIdentity.PrincipalID, ClientID: clientID})
+				}
+			}
+		}
+	}
+
+	// Check individual VMs (availability set scenario)
+	log.Printf("Listing VMs in resource group %s ...", resourceGroup)
+	vmPager := az.vmClient.NewListPager(resourceGroup, nil)
+	for vmPager.More() {
+		page, err := vmPager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list VMs in resource group %s: %v", resourceGroup, err)
+		}
+		for _, vm := range page.Value {
+			name := ""
+			if vm.Name != nil {
+				name = *vm.Name
+			}
+			if vm.Identity == nil {
+				log.Printf("VM %s has no managed identity, skipping", name)
+				continue
+			}
+			// System-assigned identity
+			if vm.Identity.PrincipalID != nil && *vm.Identity.PrincipalID != "" {
+				log.Printf("VM %s: found system-assigned identity, principalID=%s", name, *vm.Identity.PrincipalID)
+				identities = append(identities, NodeIdentityInfo{PrincipalID: *vm.Identity.PrincipalID})
+			}
+			// User-assigned identities
+			for uaID, uaIdentity := range vm.Identity.UserAssignedIdentities {
+				if uaIdentity != nil && uaIdentity.PrincipalID != nil && *uaIdentity.PrincipalID != "" {
+					clientID := ""
+					if uaIdentity.ClientID != nil {
+						clientID = *uaIdentity.ClientID
+					}
+					log.Printf("VM %s: found user-assigned identity %s, principalID=%s, clientID=%s", name, uaID, *uaIdentity.PrincipalID, clientID)
+					identities = append(identities, NodeIdentityInfo{PrincipalID: *uaIdentity.PrincipalID, ClientID: clientID})
+				}
+			}
+		}
+	}
+
+	if len(identities) == 0 {
+		return nil, fmt.Errorf("no VMSS or VM with managed identity found in resource group %s", resourceGroup)
+	}
+
+	// Deduplicate by principalID
+	seen := make(map[string]bool)
+	unique := identities[:0]
+	for _, id := range identities {
+		if !seen[id.PrincipalID] {
+			seen[id.PrincipalID] = true
+			unique = append(unique, id)
+		}
+	}
+	log.Printf("Found %d unique identities in resource group %s", len(unique), resourceGroup)
+	return unique, nil
+}
+
+// AssignRoleToIdentity assigns an Azure role to a principal on a resource group scope.
+// roleDefinitionID should be just the GUID of the role definition.
+func (az *Client) AssignRoleToIdentity(ctx context.Context, resourceGroup, principalID, roleDefinitionID string) error {
+	scope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", az.subscriptionID, resourceGroup)
+	fullRoleDefID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", az.subscriptionID, roleDefinitionID)
+
+	// Deterministic assignment ID based on scope+principal+role to avoid duplicate assignments on retry
+	assignmentID := uuid.NewSHA1(uuid.NameSpaceURL, []byte(scope+"|"+principalID+"|"+roleDefinitionID)).String()
+
+	_, err := az.roleClient.Create(ctx, scope, assignmentID, armauthorization.RoleAssignmentCreateParameters{
+		Properties: &armauthorization.RoleAssignmentProperties{
+			PrincipalID:      &principalID,
+			PrincipalType:    to.Ptr(armauthorization.PrincipalTypeServicePrincipal),
+			RoleDefinitionID: &fullRoleDefID,
+		},
+	}, nil)
+	if err != nil {
+		// Ignore conflict only when role assignment already exists
+		var respErr *azcore.ResponseError
+		if ok := errors.As(err, &respErr); ok && respErr.StatusCode == http.StatusConflict && respErr.ErrorCode == "RoleAssignmentExists" {
+			return nil
+		}
+		return fmt.Errorf("failed to create role assignment for principal %s with role %s on scope %s: %v", principalID, roleDefinitionID, scope, err)
+	}
+	return nil
+}
+
+// EnsureNodeStorageBlobDataRole gets the node identities from VMSS and VMs in the given
+// resource group and assigns them the "Storage Blob Data Contributor" role.
+// Returns the first user-assigned identity client ID for use in StorageClass parameters.
+func (az *Client) EnsureNodeStorageBlobDataRole(ctx context.Context, resourceGroup string) (string, error) {
+	log.Printf("Begin to assign Storage Blob Data Contributor role to node identities in resource group %s", resourceGroup)
+	identities, err := az.GetNodeIdentityInfo(ctx, resourceGroup)
+	if err != nil {
+		log.Printf("Failed to get node identity info: %v", err)
+		return "", err
+	}
+
+	// Storage Blob Data Contributor
+	const storageBlobDataContributorRoleID = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+	var firstClientID string
+	for _, identity := range identities {
+		log.Printf("Assigning Storage Blob Data Contributor role to principal %s ...", identity.PrincipalID)
+		if err := az.AssignRoleToIdentity(ctx, resourceGroup, identity.PrincipalID, storageBlobDataContributorRoleID); err != nil {
+			log.Printf("Failed to assign role to principal %s: %v", identity.PrincipalID, err)
+			return "", err
+		}
+		log.Printf("Successfully assigned Storage Blob Data Contributor role to principal %s", identity.PrincipalID)
+		if firstClientID == "" && identity.ClientID != "" {
+			firstClientID = identity.ClientID
+		}
+	}
+	log.Printf("Successfully assigned Storage Blob Data Contributor role to all %d node identities", len(identities))
+	return firstClientID, nil
 }


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it
Adds an e2e test for blobfuse dynamic provisioning with managed identity (MSI) authentication, similar to kubernetes-sigs/azurefile-csi-driver#3110.

### Changes:
1. **`test/utils/azure/azure_helper.go`**: Added VMSS/VM client and role assignment helpers:
   - `GetNodeIdentityInfo()` — discovers managed identities (system + user-assigned) from VMSS and VMs
   - `AssignRoleToIdentity()` — assigns Azure RBAC role with idempotent handling (deterministic assignment ID to avoid duplicates on retry)
   - `EnsureNodeStorageBlobDataRole()` — assigns **Storage Blob Data Contributor** role to all node identities and returns the first user-assigned identity client ID

2. **`test/e2e/suite_test.go`**:
   - Added CAPZ detection (`NODE_MACHINE_TYPE` / `AZURE_NODE_MACHINE_TYPE` env vars)
   - MI role setup in `BeforeSuite` with graceful degradation (warns on failure, test skips)
   - 60-second RBAC propagation wait after role assignment to handle Azure eventual consistency
   - Passes MI setup result to all Ginkgo processes via the `SynchronizedBeforeSuite` data channel

3. **`test/e2e/dynamic_provisioning_test.go`**: New test case — creates a volume with `AzureStorageAuthType=MSI` and `AzureStorageIdentityClientID` set to the kubelet identity client ID

4. **`go.mod`**: Promoted `armauthorization/v2` and `armcompute/v7` from indirect to direct dependencies

### How it works:
- In CAPZ environments, `BeforeSuite` discovers node managed identities and assigns them the Storage Blob Data Contributor role on the resource group
- After role assignment, waits 60s for Azure RBAC propagation before proceeding
- The test creates a StorageClass with MSI auth parameters (`Premium_LRS`, `fuse` protocol) and verifies dynamic provisioning + pod mount works
- Skipped gracefully on non-CAPZ clusters or when MI setup fails

## Which issue(s) this PR fixes
Ref: kubernetes-sigs/azurefile-csi-driver#3110

## Does this PR introduce a user-facing change?
```release-note
NONE
```