### PR TITLE
test: add e2e test for dynamic provisioning with workload identity token mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
@@ -54,7 +55,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"sigs.k8s.io/blob-csi-driver/test/e2e/driver"
@@ -28,6 +29,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -1189,5 +1191,84 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			StorageClassParameters: scParameters,
 		}
 		test.Run(ctx, cs, ns)
+	})
+
+	ginkgo.It("should create a volume on demand with workload identity token mount [blob.csi.azure.com]", ginkgo.Serial, func(ctx ginkgo.SpecContext) {
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for CAPZ test")
+		}
+
+		// Wait for background AAD OIDC cache warm-up to finish.
+		// The warm-up goroutine started during SynchronizedBeforeSuite and
+		// runs in parallel with other tests, so by the time this Serial
+		// test runs (last), the AAD cache is usually already warm.
+		ginkgo.By("Waiting for AAD OIDC cache warm-up to complete")
+		<-wiReady
+
+		gomega.Expect(wiClientID).NotTo(gomega.BeEmpty(), "WI client ID not set after background warm-up")
+		gomega.Expect(errWISetup).NotTo(gomega.HaveOccurred(),
+			"background AAD OIDC warm-up failed; WI mount will not work")
+		clientID := wiClientID
+
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"-o allow_other",
+							"--file-cache-timeout-in-seconds=120",
+							"--cancel-list-on-mount-seconds=0",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		scParameters := map[string]string{
+			"skuName":                        "Premium_LRS",
+			"protocol":                       "fuse2",
+			"mountWithWorkloadIdentityToken": "true",
+			"clientID":                       clientID,
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: scParameters,
+			ServiceAccountName:     wiServiceAccountName,
+		}
+		// Use default namespace because the federated identity credential is bound to
+		// system:serviceaccount:default:<sa-name>, so the SA must be in default namespace.
+		// Apply the privileged pod security label to avoid PodSecurity admission rejections.
+		defaultNS, err := cs.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if defaultNS.Labels == nil {
+			defaultNS.Labels = make(map[string]string)
+		}
+		originalEnforce, hadLabel := defaultNS.Labels["pod-security.kubernetes.io/enforce"]
+		defaultNS.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+		defaultNS, err = cs.CoreV1().Namespaces().Update(ctx, defaultNS, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			nsToRestore, restoreErr := cs.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
+			if restoreErr != nil {
+				log.Printf("WARNING: failed to get default namespace for label restore: %v", restoreErr)
+				return
+			}
+			if hadLabel {
+				nsToRestore.Labels["pod-security.kubernetes.io/enforce"] = originalEnforce
+			} else {
+				delete(nsToRestore.Labels, "pod-security.kubernetes.io/enforce")
+			}
+			_, restoreErr = cs.CoreV1().Namespaces().Update(ctx, nsToRestore, metav1.UpdateOptions{})
+			if restoreErr != nil {
+				log.Printf("WARNING: failed to restore pod-security label on default namespace: %v", restoreErr)
+			}
+		}()
+		test.Run(ctx, cs, defaultNS)
 	})
 })

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -293,9 +293,6 @@ const (
 	wiServiceAccountName         = "blob-wi-test-sa"
 	wiServiceAccountNamespace    = "default"
 	wiStorageBlobDataContributor = "ba92f5b4-2d11-453d-a403-e96b0029c9fe" // Storage Blob Data Contributor role GUID
-	// wiPropagationWait is the time to wait for ARM FIC + RBAC propagation.
-	// AAD OIDC metadata cache is handled separately by waitForAADTokenExchange.
-	wiPropagationWait = 2 * time.Minute
 )
 
 // configureWorkloadIdentity sets up workload identity resources (fast, sync):
@@ -406,9 +403,9 @@ func configureWorkloadIdentity(ctx context.Context, cs clientset.Interface, azur
 	}
 	log.Printf("Assigned Storage Blob Data Contributor role to identity")
 
-	// Wait for ARM eventual consistency (FIC + RBAC propagation)
-	log.Printf("Waiting %v for FIC and RBAC propagation...", wiPropagationWait)
-	time.Sleep(wiPropagationWait)
+	// Skip static sleep for FIC/RBAC propagation — the token exchange retry
+	// loop (waitForAADTokenExchange) naturally handles FIC propagation delay,
+	// and RBAC propagation completes well before the actual CSI mount runs.
 
 	// Verify OIDC JWKS endpoint is accessible and contains signing keys.
 	// AAD validates SA tokens by fetching the JWKS from the OIDC issuer.

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -18,9 +18,16 @@ package e2e
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -29,10 +36,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/gomega"
 	"github.com/pborman/uuid"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
@@ -53,6 +69,18 @@ var isAzureStackCloud = strings.EqualFold(os.Getenv("AZURE_CLOUD_NAME"), "AZURES
 var isCapzTest = os.Getenv("NODE_MACHINE_TYPE") != "" || os.Getenv("AZURE_NODE_MACHINE_TYPE") != ""
 var blobDriver *blob.Driver
 var projectRoot string
+
+// wiClientID is pre-populated during SynchronizedBeforeSuite so that the
+// AAD OIDC cache warm-up happens in parallel with the CSI driver bootstrap,
+// avoiding a ~20 min delay when the WI test actually runs.
+var wiClientID string
+
+// wiReady is closed when the background AAD OIDC cache warm-up finishes
+// (successfully or with an error stored in errWISetup).
+var wiReady = make(chan struct{})
+
+// errWISetup holds any error from the background WI warm-up goroutine.
+var errWISetup error
 
 type testCmd struct {
 	command  string
@@ -109,8 +137,59 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx ginkgo.SpecContext) []byte {
 		endLog:   "metrics service created",
 	}
 	execTestCmd([]testCmd{e2eBootstrap, createMetricsSVC})
-	return nil
-}, func(_ ginkgo.SpecContext, _ []byte) {
+
+	// Pre-warm AAD OIDC cache for workload identity test.
+	// AAD independently caches OIDC metadata and can take 20-30+ min to
+	// accept token exchanges for a new OIDC issuer (AADSTS7000272).
+	// We run the fast configuration steps (FIC, SA, RBAC) synchronously,
+	// then kick off the slow AAD token exchange wait in a background
+	// goroutine so that other tests can run in parallel. The WI test
+	// blocks on wiReady channel when it needs the client ID.
+	var clientID string
+	if isCapzTest {
+		kubeconfig := os.Getenv(kubeconfigEnvVar)
+		if kubeconfig == "" {
+			kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		}
+		cs, csErr := util.GetKubeClient(kubeconfig, 25.0, 50, "")
+		gomega.Expect(csErr).NotTo(gomega.HaveOccurred())
+		clientID, err = configureWorkloadIdentity(ctx, cs, azureClient, creds)
+		if err != nil {
+			log.Printf("WARNING: WI configuration failed: %v", err)
+			clientID = ""
+		}
+	}
+
+	return []byte(clientID)
+}, func(_ ginkgo.SpecContext, data []byte) {
+	// Store pre-configured WI client ID from node 1 and start background
+	// AAD OIDC cache warm-up. The WI test will block on wiReady channel.
+	if len(data) > 0 {
+		wiClientID = string(data)
+		log.Printf("Received WI clientID: %s, starting background AAD warm-up", wiClientID)
+		go func() {
+			defer close(wiReady)
+			kubeconfig := os.Getenv(kubeconfigEnvVar)
+			if kubeconfig == "" {
+				kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
+			}
+			bgCS, err := util.GetKubeClient(kubeconfig, 25.0, 50, "")
+			if err != nil {
+				errWISetup = fmt.Errorf("failed to create kube client for WI warm-up: %v", err)
+				log.Printf("WARNING: %v", errWISetup)
+				return
+			}
+			if err := waitForAADTokenExchange(context.Background(), bgCS, wiClientID, 45*time.Minute); err != nil {
+				errWISetup = fmt.Errorf("AAD token exchange not ready: %v", err)
+				log.Printf("WARNING: WI background warm-up failed: %v", errWISetup)
+			} else {
+				log.Printf("AAD token exchange warm-up succeeded in background")
+			}
+		}()
+	} else {
+		close(wiReady) // No WI setup needed, unblock immediately
+	}
+
 	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
 	// it does not fall back to defaults
 	if os.Getenv(kubeconfigEnvVar) == "" {
@@ -209,3 +288,587 @@ func checkAccountCreationLeak(ctx context.Context) {
 	accountLimitInTest := 22
 	gomega.Expect(accountNum >= accountLimitInTest).To(gomega.BeFalse())
 }
+
+const (
+	wiServiceAccountName         = "blob-wi-test-sa"
+	wiServiceAccountNamespace    = "default"
+	wiStorageBlobDataContributor = "ba92f5b4-2d11-453d-a403-e96b0029c9fe" // Storage Blob Data Contributor role GUID
+	// wiPropagationWait is the time to wait for ARM FIC + RBAC propagation.
+	// AAD OIDC metadata cache is handled separately by waitForAADTokenExchange.
+	wiPropagationWait = 2 * time.Minute
+)
+
+// configureWorkloadIdentity sets up workload identity resources (fast, sync):
+// 1. Discovers the OIDC issuer URL from kube-apiserver
+// 2. Gets the node identity client ID and principal ID
+// 3. Creates a federated identity credential
+// 4. Creates a Kubernetes service account with WI annotation
+// 5. Assigns Storage Blob Data Contributor role to the identity
+// 6. Waits for OIDC JWKS endpoint to be accessible
+// Returns the identity client ID. Does NOT wait for AAD token exchange
+// (that happens in a background goroutine to avoid blocking BeforeSuite).
+func configureWorkloadIdentity(ctx context.Context, cs clientset.Interface, azureClient *azure.Client, creds *credentials.Credentials) (string, error) {
+	log.Println("Configuring workload identity for e2e tests...")
+
+	// Step 1: Discover OIDC issuer URL from kube-apiserver
+	oidcIssuerURL, err := discoverOIDCIssuer(ctx, cs)
+	if err != nil {
+		return "", fmt.Errorf("failed to discover OIDC issuer: %v", err)
+	}
+	log.Printf("Discovered OIDC issuer URL: %s", oidcIssuerURL)
+
+	// Step 2: Get node identity info
+	identityInfo, err := azureClient.GetFirstUserAssignedIdentity(ctx, creds.ResourceGroup)
+	if err != nil {
+		return "", fmt.Errorf("failed to get node identity: %v", err)
+	}
+	log.Printf("Node identity clientID: %s, principalID: %s", identityInfo.ClientID, identityInfo.PrincipalID)
+
+	// Parse identity name and resource group from resource ID
+	parts := strings.Split(identityInfo.ResourceID, "/")
+	if len(parts) < 9 || !strings.EqualFold(parts[3], "resourceGroups") || !strings.EqualFold(parts[7], "userAssignedIdentities") {
+		return "", fmt.Errorf("invalid identity resource ID format: %s", identityInfo.ResourceID)
+	}
+	identityRG := parts[4]
+	identityName := parts[8]
+	log.Printf("Identity resource group: %s, name: %s", identityRG, identityName)
+
+	// Step 3: Create federated identity credential with deterministic name.
+	// Use a fixed name so that concurrent/repeated runs reuse the same FIC
+	// instead of leaking new ones on every run. Handle 409 Conflict gracefully
+	// when the issuer+subject combination already exists.
+	ficName := "blob-e2e-wi-fic"
+	subject := fmt.Sprintf("system:serviceaccount:%s:%s", wiServiceAccountNamespace, wiServiceAccountName)
+	log.Printf("Creating FIC: identity=%s/%s, issuer=%s, subject=%s", identityRG, identityName, oidcIssuerURL, subject)
+	err = azureClient.CreateFederatedIdentityCredential(ctx, identityRG, identityName, ficName, oidcIssuerURL, subject)
+	if err != nil {
+		// A 409 with "issuer/subject combination already exists" means a matching FIC is present; safe to reuse.
+		// Any other 409 (concurrent update, quota, etc.) should be treated as a real failure.
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusConflict &&
+			strings.Contains(respErr.Error(), "already exists") {
+			log.Printf("Federated identity credential already exists (issuer+subject match), reusing")
+		} else {
+			return "", fmt.Errorf("failed to create federated identity credential: %v", err)
+		}
+	} else {
+		log.Printf("Federated identity credential created: %s", ficName)
+	}
+
+	// Step 4: Create or update Kubernetes service account with WI annotation
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wiServiceAccountName,
+			Namespace: wiServiceAccountNamespace,
+			Labels: map[string]string{
+				"azure.workload.identity/use": "true",
+			},
+			Annotations: map[string]string{
+				"azure.workload.identity/client-id": identityInfo.ClientID,
+				"azure.workload.identity/tenant-id": creds.TenantID,
+			},
+		},
+	}
+	_, err = cs.CoreV1().ServiceAccounts(wiServiceAccountNamespace).Create(ctx, sa, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.Printf("Service account %s already exists, updating...", wiServiceAccountName)
+			existing, getErr := cs.CoreV1().ServiceAccounts(wiServiceAccountNamespace).Get(ctx, wiServiceAccountName, metav1.GetOptions{})
+			if getErr != nil {
+				return "", fmt.Errorf("failed to get existing service account: %v", getErr)
+			}
+			if existing.Labels == nil {
+				existing.Labels = make(map[string]string)
+			}
+			for k, v := range sa.Labels {
+				existing.Labels[k] = v
+			}
+			if existing.Annotations == nil {
+				existing.Annotations = make(map[string]string)
+			}
+			for k, v := range sa.Annotations {
+				existing.Annotations[k] = v
+			}
+			_, err = cs.CoreV1().ServiceAccounts(wiServiceAccountNamespace).Update(ctx, existing, metav1.UpdateOptions{})
+			if err != nil {
+				return "", fmt.Errorf("failed to update service account: %v", err)
+			}
+		} else {
+			return "", fmt.Errorf("failed to create service account: %v", err)
+		}
+	}
+	log.Printf("Service account %s created/updated in namespace %s", wiServiceAccountName, wiServiceAccountNamespace)
+
+	// Step 5: Assign Storage Blob Data Contributor role to identity
+	err = azureClient.AssignRoleToIdentity(ctx, creds.ResourceGroup, identityInfo.PrincipalID, wiStorageBlobDataContributor)
+	if err != nil {
+		return "", fmt.Errorf("failed to assign Storage Blob Data Contributor role: %v", err)
+	}
+	log.Printf("Assigned Storage Blob Data Contributor role to identity")
+
+	// Wait for ARM eventual consistency (FIC + RBAC propagation)
+	log.Printf("Waiting %v for FIC and RBAC propagation...", wiPropagationWait)
+	time.Sleep(wiPropagationWait)
+
+	// Verify OIDC JWKS endpoint is accessible and contains signing keys.
+	// AAD validates SA tokens by fetching the JWKS from the OIDC issuer.
+	// In CAPZ clusters the JWKS is served from Azure Blob Storage and may
+	// not be immediately available after cluster creation, leading to
+	// AADSTS7000272 errors during token exchange.
+	if err := waitForOIDCJWKS(oidcIssuerURL, 5*time.Minute); err != nil {
+		return "", fmt.Errorf("OIDC JWKS not ready: %v", err)
+	}
+
+	// Verify the OIDC issuer's JWKS contains the key used by kube-apiserver
+	// to sign ServiceAccount tokens. In CAPZ clusters, the JWKS is uploaded
+	// to Azure Blob Storage during cluster creation, but the apiserver may
+	// use a different signing key if the key pair was rotated or if there was
+	// a race during bootstrap. If the keys don't match, AAD will permanently
+	// reject token exchanges with AADSTS7000272.
+	if err := verifyJWKSKeyMatch(ctx, cs, oidcIssuerURL, creds); err != nil {
+		return "", fmt.Errorf("OIDC JWKS key mismatch: %v", err)
+	}
+
+	// NOTE: AAD OIDC cache warm-up (waitForAADTokenExchange) runs in a
+	// background goroutine started from SynchronizedBeforeSuite's second
+	// func, so it does not block other tests from starting.
+
+	return identityInfo.ClientID, nil
+}
+
+// discoverOIDCIssuer retrieves the OIDC issuer URL from the kube-apiserver's
+// well-known OpenID configuration endpoint.
+func discoverOIDCIssuer(ctx context.Context, cs clientset.Interface) (string, error) {
+	result := cs.Discovery().RESTClient().Get().AbsPath("/.well-known/openid-configuration").Do(ctx)
+	body, err := result.Raw()
+	if err != nil {
+		return "", fmt.Errorf("failed to get OIDC configuration: %v", err)
+	}
+
+	var oidcConfig struct {
+		Issuer string `json:"issuer"`
+	}
+	if err := json.Unmarshal(body, &oidcConfig); err != nil {
+		return "", fmt.Errorf("failed to parse OIDC configuration: %v", err)
+	}
+	if oidcConfig.Issuer == "" {
+		return "", fmt.Errorf("OIDC issuer URL is empty in cluster configuration")
+	}
+	return oidcConfig.Issuer, nil
+}
+
+// waitForOIDCJWKS polls the OIDC issuer's JWKS endpoint until it returns a
+// valid response containing at least one signing key. This guards against the
+// race where AAD tries to validate a SA token before the JWKS document is
+// published (AADSTS7000272).
+func waitForOIDCJWKS(issuerURL string, timeout time.Duration) error {
+	jwksURL := strings.TrimSuffix(issuerURL, "/") + "/openid/v1/jwks"
+	log.Printf("Waiting up to %v for OIDC JWKS to be available at %s", timeout, jwksURL)
+
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		},
+	}
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := httpClient.Get(jwksURL) //nolint:gosec // URL is constructed from cluster OIDC issuer, not user input
+		if err != nil {
+			lastErr = fmt.Errorf("GET %s: %v", jwksURL, err)
+			log.Printf("JWKS not ready: %v, retrying...", lastErr)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("reading JWKS response: %v", err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("JWKS returned status %d", resp.StatusCode)
+			log.Printf("JWKS not ready: %v, retrying...", lastErr)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		var jwks struct {
+			Keys []json.RawMessage `json:"keys"`
+		}
+		if err := json.Unmarshal(body, &jwks); err != nil {
+			lastErr = fmt.Errorf("parsing JWKS: %v", err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+		if len(jwks.Keys) == 0 {
+			lastErr = fmt.Errorf("JWKS contains no keys")
+			log.Printf("JWKS not ready: %v, retrying...", lastErr)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		log.Printf("OIDC JWKS is ready with %d key(s)", len(jwks.Keys))
+		return nil
+	}
+	return fmt.Errorf("timed out waiting for OIDC JWKS: %v", lastErr)
+}
+
+// verifyJWKSKeyMatch ensures the OIDC issuer's JWKS (hosted on Azure Blob
+// Storage for CAPZ clusters) contains the signing key actually used by
+// kube-apiserver. CAPZ uploads the JWKS during cluster creation, but a race
+// condition can cause the blob to contain a stale key while the apiserver
+// uses a different one. When this happens, AAD permanently rejects token
+// exchanges with AADSTS7000272 ("certificate ... could not be found in the
+// metadata of identity provider"). This function detects the mismatch and
+// fixes it by re-uploading the correct JWKS to the blob.
+func verifyJWKSKeyMatch(ctx context.Context, cs clientset.Interface, issuerURL string, creds *credentials.Credentials) error {
+	// 1. Create a SA token and extract the kid from its JWT header
+	tokenReq := &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			Audiences:         []string{"api://AzureADTokenExchange"},
+			ExpirationSeconds: int64Ptr(600),
+		},
+	}
+	tokenResp, err := cs.CoreV1().ServiceAccounts("default").
+		CreateToken(ctx, "default", tokenReq, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating SA token: %v", err)
+	}
+
+	tokenKid, err := extractJWTKid(tokenResp.Status.Token)
+	if err != nil {
+		return fmt.Errorf("extracting kid from SA token: %v", err)
+	}
+	log.Printf("SA token kid: %s", tokenKid)
+
+	// 2. Fetch JWKS from the OIDC issuer blob URL and extract kids
+	jwksURL := strings.TrimSuffix(issuerURL, "/") + "/openid/v1/jwks"
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Get(jwksURL) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("fetching JWKS from %s: %v", jwksURL, err)
+	}
+	blobJWKSBody, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("reading JWKS response: %v", err)
+	}
+
+	blobKids, err := extractJWKSKids(blobJWKSBody)
+	if err != nil {
+		return fmt.Errorf("parsing blob JWKS: %v", err)
+	}
+	log.Printf("Blob JWKS kids: %v", blobKids)
+
+	// 3. Check if the SA token kid is present in the blob JWKS
+	found := false
+	for _, kid := range blobKids {
+		if kid == tokenKid {
+			found = true
+			break
+		}
+	}
+	if found {
+		log.Printf("JWKS key match verified: SA token kid %s found in blob JWKS", tokenKid)
+		return nil
+	}
+
+	log.Printf("WARNING: JWKS key mismatch detected! SA token kid %s not in blob JWKS %v", tokenKid, blobKids)
+	log.Printf("Fetching correct JWKS from kube-apiserver and re-uploading to blob storage...")
+
+	// 4. Fetch the correct JWKS from kube-apiserver
+	result := cs.Discovery().RESTClient().Get().AbsPath("/openid/v1/jwks").Do(ctx)
+	apiJWKS, err := result.Raw()
+	if err != nil {
+		return fmt.Errorf("fetching JWKS from apiserver: %v", err)
+	}
+
+	// Verify the apiserver JWKS contains our kid
+	apiKids, err := extractJWKSKids(apiJWKS)
+	if err != nil {
+		return fmt.Errorf("parsing apiserver JWKS: %v", err)
+	}
+	log.Printf("Apiserver JWKS kids: %v", apiKids)
+
+	// Fail fast if the apiserver JWKS also lacks our token's kid
+	apiHasKid := false
+	for _, kid := range apiKids {
+		if kid == tokenKid {
+			apiHasKid = true
+			break
+		}
+	}
+	if !apiHasKid {
+		return fmt.Errorf("apiserver JWKS does not contain token kid %s (has %v); cannot repair", tokenKid, apiKids)
+	}
+
+	// 5. Extract storage account and blob service URL from OIDC issuer URL
+	// Format: https://<storageaccount>.z1.web.core.windows.net/
+	storageAccount, blobServiceURL, err := extractStorageInfoFromIssuer(issuerURL)
+	if err != nil {
+		return fmt.Errorf("extracting storage info from issuer URL: %v", err)
+	}
+	log.Printf("OIDC storage account: %s, blob service: %s", storageAccount, blobServiceURL)
+
+	// 6. Upload corrected JWKS to the $web container
+	if err := uploadJWKSToBlob(blobServiceURL, apiJWKS, creds); err != nil {
+		return fmt.Errorf("uploading corrected JWKS: %v", err)
+	}
+
+	// 7. Also upload the openid-configuration if needed
+	// Preserve the original issuer URL (including trailing slash if present)
+	// to match the FIC issuer configuration exactly.
+	oidcConfig := fmt.Sprintf(`{"issuer":"%s","jwks_uri":"%s","response_types_supported":["id_token"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"]}`,
+		issuerURL, jwksURL)
+	if err := uploadOIDCConfigToBlob(blobServiceURL, []byte(oidcConfig), creds); err != nil {
+		log.Printf("WARNING: failed to upload openid-configuration: %v (non-fatal)", err)
+	}
+
+	log.Printf("Successfully re-uploaded JWKS to blob storage, waiting for AAD cache refresh...")
+	return nil
+}
+
+// extractJWTKid parses a JWT token (without validation) and returns the "kid"
+// from its header.
+func extractJWTKid(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("invalid JWT: expected 3 parts, got %d", len(parts))
+	}
+	// Pad base64url if needed
+	headerB64 := parts[0]
+	if m := len(headerB64) % 4; m != 0 {
+		headerB64 += strings.Repeat("=", 4-m)
+	}
+	headerBytes, err := base64.URLEncoding.DecodeString(headerB64)
+	if err != nil {
+		return "", fmt.Errorf("decoding JWT header: %v", err)
+	}
+	var header struct {
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return "", fmt.Errorf("parsing JWT header: %v", err)
+	}
+	if header.Kid == "" {
+		return "", fmt.Errorf("JWT header has no kid")
+	}
+	return header.Kid, nil
+}
+
+// extractJWKSKids extracts all "kid" values from a JWKS document.
+func extractJWKSKids(jwksBody []byte) ([]string, error) {
+	var jwks struct {
+		Keys []struct {
+			Kid string `json:"kid"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(jwksBody, &jwks); err != nil {
+		return nil, fmt.Errorf("parsing JWKS: %v", err)
+	}
+	var kids []string
+	for _, k := range jwks.Keys {
+		if k.Kid != "" {
+			kids = append(kids, k.Kid)
+		}
+	}
+	return kids, nil
+}
+
+// extractStorageInfoFromIssuer extracts the storage account name and blob
+// service URL from a CAPZ OIDC issuer URL.
+// e.g., https://capzoidcXXX.z1.web.core.windows.net/ →
+//
+//	account: capzoidcXXX, blobURL: https://capzoidcXXX.blob.core.windows.net
+func extractStorageInfoFromIssuer(issuerURL string) (account string, blobServiceURL string, err error) {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return "", "", err
+	}
+	// hostname is like capzoidcXXX.z1.web.core.windows.net
+	parts := strings.SplitN(u.Hostname(), ".", 2)
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("unexpected issuer hostname: %s", u.Hostname())
+	}
+	account = parts[0]
+	// parts[1] is like "z1.web.core.windows.net"; extract storage suffix
+	// Blob endpoints don't include the zone prefix, so strip "z1." and replace "web." with "blob."
+	// z1.web.core.windows.net → blob.core.windows.net
+	hostSuffix := parts[1]
+	webIdx := strings.Index(hostSuffix, "web.")
+	if webIdx < 0 {
+		return "", "", fmt.Errorf("unexpected issuer hostname (no 'web.' segment): %s", u.Hostname())
+	}
+	// Everything after "web." is the storage suffix (e.g., "core.windows.net")
+	storageSuffix := hostSuffix[webIdx+4:]
+	blobServiceURL = fmt.Sprintf("https://%s.blob.%s", account, storageSuffix)
+	return account, blobServiceURL, nil
+}
+
+// uploadJWKSToBlob uploads the JWKS document to the $web container of the
+// OIDC storage account at path openid/v1/jwks.
+// getAzureCredential creates an Azure credential from test credentials,
+// supporting both client secret and federated token authentication.
+func getAzureCredential(creds *credentials.Credentials) (azcore.TokenCredential, error) {
+	// Derive cloud configuration for sovereign cloud support.
+	var cloudCfg cloud.Configuration
+	switch strings.ToUpper(os.Getenv("AZURE_CLOUD_NAME")) {
+	case "AZURECHINACLOUD":
+		cloudCfg = cloud.AzureChina
+	case "AZUREUSGOVERNMENTCLOUD":
+		cloudCfg = cloud.AzureGovernment
+	default:
+		cloudCfg = cloud.AzurePublic
+	}
+	if host := os.Getenv("AZURE_AUTHORITY_HOST"); host != "" {
+		cloudCfg.ActiveDirectoryAuthorityHost = host
+	}
+
+	if creds.AADFederatedTokenFile != "" {
+		return azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+			ClientOptions: azcore.ClientOptions{Cloud: cloudCfg},
+			TenantID:      creds.TenantID,
+			ClientID:      creds.AADClientID,
+			TokenFilePath: creds.AADFederatedTokenFile,
+		})
+	}
+	return azidentity.NewClientSecretCredential(creds.TenantID, creds.AADClientID, creds.AADClientSecret,
+		&azidentity.ClientSecretCredentialOptions{
+			ClientOptions: azcore.ClientOptions{Cloud: cloudCfg},
+		})
+}
+
+func uploadJWKSToBlob(blobServiceURL string, jwksBody []byte, creds *credentials.Credentials) error {
+	azCred, err := getAzureCredential(creds)
+	if err != nil {
+		return fmt.Errorf("creating Azure credential: %v", err)
+	}
+	client, err := azblob.NewClient(blobServiceURL, azCred, nil)
+	if err != nil {
+		return fmt.Errorf("creating blob client: %v", err)
+	}
+	_, err = client.UploadBuffer(context.Background(), "$web", "openid/v1/jwks", jwksBody, nil)
+	if err != nil {
+		return fmt.Errorf("uploading JWKS blob: %v", err)
+	}
+	log.Printf("Uploaded corrected JWKS (%d bytes) to %s/$web/openid/v1/jwks", len(jwksBody), blobServiceURL)
+	return nil
+}
+
+// uploadOIDCConfigToBlob uploads the openid-configuration to the $web
+// container at .well-known/openid-configuration.
+func uploadOIDCConfigToBlob(blobServiceURL string, configBody []byte, creds *credentials.Credentials) error {
+	azCred, err := getAzureCredential(creds)
+	if err != nil {
+		return fmt.Errorf("creating Azure credential: %v", err)
+	}
+	client, err := azblob.NewClient(blobServiceURL, azCred, nil)
+	if err != nil {
+		return fmt.Errorf("creating blob client: %v", err)
+	}
+	_, err = client.UploadBuffer(context.Background(), "$web", ".well-known/openid-configuration", configBody, nil)
+	return err
+}
+
+// AAD independently caches OIDC metadata; even after the JWKS endpoint
+// returns keys, AAD may still reject token exchanges with AADSTS7000272
+// until its internal cache refreshes. This function creates a short-lived
+// service account token and attempts a client_credentials + client_assertion
+// exchange against the AAD token endpoint, retrying until success or timeout.
+func waitForAADTokenExchange(ctx context.Context, cs clientset.Interface, clientID string, timeout time.Duration) error {
+	log.Printf("Waiting up to %v for AAD to accept token exchange for client %s", timeout, clientID)
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		// Create a short-lived SA token via TokenRequest API
+		tokenReq := &authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{
+				Audiences:         []string{"api://AzureADTokenExchange"},
+				ExpirationSeconds: int64Ptr(600),
+			},
+		}
+		tokenResp, err := cs.CoreV1().ServiceAccounts(wiServiceAccountNamespace).
+			CreateToken(ctx, wiServiceAccountName, tokenReq, metav1.CreateOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("creating SA token: %v", err)
+			log.Printf("Token exchange check: %v, retrying...", lastErr)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+
+		saToken := tokenResp.Status.Token
+
+		// Try exchanging with AAD
+		// Use the well-known Azure AD v2 token endpoint
+		tenantID := os.Getenv("AZURE_TENANT_ID")
+		if tenantID == "" {
+			// Try to get from credentials file
+			creds, credErr := credentials.CreateAzureCredentialFile()
+			if credErr == nil {
+				tenantID = creds.TenantID
+			}
+		}
+		if tenantID == "" {
+			return fmt.Errorf("AZURE_TENANT_ID not set and not available from credentials")
+		}
+
+		authorityHost := os.Getenv("AZURE_AUTHORITY_HOST")
+		if authorityHost == "" {
+			cloudName := os.Getenv("AZURE_CLOUD_NAME")
+			switch strings.ToUpper(cloudName) {
+			case "AZURECHINACLOUD":
+				authorityHost = "https://login.chinacloudapi.cn"
+			case "AZUREUSGOVERNMENTCLOUD":
+				authorityHost = "https://login.microsoftonline.us"
+			default:
+				authorityHost = "https://login.microsoftonline.com"
+			}
+		}
+
+		tokenURL := fmt.Sprintf("%s/%s/oauth2/v2.0/token", strings.TrimSuffix(authorityHost, "/"), tenantID)
+		data := fmt.Sprintf(
+			"grant_type=client_credentials&client_id=%s&scope=https://storage.azure.com/.default"+
+				"&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"+
+				"&client_assertion=%s",
+			clientID, saToken)
+
+		resp, err := httpClient.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(data)) //nolint:gosec,noctx
+		if err != nil {
+			lastErr = fmt.Errorf("AAD token request: %v", err)
+			log.Printf("Token exchange check: %v, retrying...", lastErr)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			log.Printf("AAD token exchange succeeded")
+			return nil
+		}
+
+		// Check if it's the expected AADSTS7000272 (OIDC not yet cached)
+		bodyStr := string(body)
+		if strings.Contains(bodyStr, "AADSTS7000272") {
+			lastErr = fmt.Errorf("AAD returned AADSTS7000272: %s", bodyStr)
+			log.Printf("Token exchange check: AADSTS7000272 response: %s, retrying in 15s...", bodyStr)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+
+		// Other AAD error — log but keep retrying (could be transient)
+		lastErr = fmt.Errorf("AAD returned status %d: %s", resp.StatusCode, bodyStr)
+		log.Printf("Token exchange check: %v, retrying...", lastErr)
+		time.Sleep(15 * time.Second)
+	}
+	return fmt.Errorf("timed out waiting for AAD token exchange: %v", lastErr)
+}
+
+func int64Ptr(i int64) *int64 { return &i }

--- a/test/e2e/testsuites/dynamically_provisioned_cmd_volume_tester.go
+++ b/test/e2e/testsuites/dynamically_provisioned_cmd_volume_tester.go
@@ -33,6 +33,7 @@ type DynamicallyProvisionedCmdVolumeTest struct {
 	CSIDriver              driver.DynamicPVTestDriver
 	Pods                   []PodDetails
 	StorageClassParameters map[string]string
+	ServiceAccountName     string
 }
 
 func (t *DynamicallyProvisionedCmdVolumeTest) Run(ctx context.Context, client clientset.Interface, namespace *v1.Namespace) {
@@ -41,6 +42,13 @@ func (t *DynamicallyProvisionedCmdVolumeTest) Run(ctx context.Context, client cl
 		// defer must be called here for resources not get removed before using them
 		for i := range cleanup {
 			defer cleanup[i](ctx)
+		}
+
+		if t.ServiceAccountName != "" {
+			tpod.SetServiceAccountName(t.ServiceAccountName)
+			// Note: AutomountServiceAccountToken is intentionally left false (default).
+			// CSI tokenRequests for workload identity are handled by kubelet based on the
+			// pod's service account; no in-container token mount is needed.
 		}
 
 		ginkgo.By("deploying the pod")

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -576,9 +576,6 @@ func (t *TestPod) SetServiceAccountName(name string) {
 	t.pod.Spec.ServiceAccountName = name
 }
 
-func (t *TestPod) SetAutomountServiceAccountToken(enabled bool) {
-	t.pod.Spec.AutomountServiceAccountToken = ptr.To(enabled)
-}
 
 func (t *TestPod) Cleanup(ctx context.Context) {
 	cleanupPodOrFail(ctx, t.client, t.pod.Name, t.namespace.Name)

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -572,6 +572,14 @@ func (t *TestPod) SetNodeSelector(nodeSelector map[string]string) {
 	t.pod.Spec.NodeSelector = nodeSelector
 }
 
+func (t *TestPod) SetServiceAccountName(name string) {
+	t.pod.Spec.ServiceAccountName = name
+}
+
+func (t *TestPod) SetAutomountServiceAccountToken(enabled bool) {
+	t.pod.Spec.AutomountServiceAccountToken = ptr.To(enabled)
+}
+
 func (t *TestPod) Cleanup(ctx context.Context) {
 	cleanupPodOrFail(ctx, t.client, t.pod.Name, t.namespace.Name)
 }

--- a/test/e2e/testsuites/testsuites.go
+++ b/test/e2e/testsuites/testsuites.go
@@ -576,7 +576,6 @@ func (t *TestPod) SetServiceAccountName(name string) {
 	t.pod.Spec.ServiceAccountName = name
 }
 
-
 func (t *TestPod) Cleanup(ctx context.Context) {
 	cleanupPodOrFail(ctx, t.client, t.pod.Name, t.namespace.Name)
 }

--- a/test/utils/azure/azure_helper.go
+++ b/test/utils/azure/azure_helper.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	armmsi "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	resources "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/google/uuid"
 	"sigs.k8s.io/blob-csi-driver/pkg/blob"
@@ -52,6 +53,7 @@ type Client struct {
 	vmssClient           *armcompute.VirtualMachineScaleSetsClient
 	vmClient             *armcompute.VirtualMachinesClient
 	roleClient           *armauthorization.RoleAssignmentsClient
+	ficClient            *armmsi.FederatedIdentityCredentialsClient
 }
 
 func GetClient(cloud, subscriptionID, clientID, tenantID, clientSecret string, aadFederatedTokenFile string) (*Client, error) {
@@ -107,6 +109,10 @@ func GetClient(cloud, subscriptionID, clientID, tenantID, clientSecret string, a
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role assignments client: %v", err)
 	}
+	ficClient, err := armmsi.NewFederatedIdentityCredentialsClient(subscriptionID, cred, armClientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create federated identity credentials client: %v", err)
+	}
 
 	return &Client{
 		subscriptionID:       subscriptionID,
@@ -119,6 +125,7 @@ func GetClient(cloud, subscriptionID, clientID, tenantID, clientSecret string, a
 		vmssClient:           vmssClient,
 		vmClient:             vmClient,
 		roleClient:           roleAssignClient,
+		ficClient:            ficClient,
 	}, nil
 }
 
@@ -173,10 +180,11 @@ func (az *Client) GetAccountNumByResourceGroup(ctx context.Context, groupName st
 	return len(result), nil
 }
 
-// NodeIdentityInfo holds the principal ID and client ID of a managed identity.
+// NodeIdentityInfo holds the principal ID, client ID, and resource ID of a managed identity.
 type NodeIdentityInfo struct {
 	PrincipalID string
 	ClientID    string
+	ResourceID  string
 }
 
 // GetNodeIdentityInfo retrieves managed identity information from VMSS and VMs in the resource group.
@@ -214,7 +222,7 @@ func (az *Client) GetNodeIdentityInfo(ctx context.Context, resourceGroup string)
 						clientID = *uaIdentity.ClientID
 					}
 					log.Printf("VMSS %s: found user-assigned identity %s, principalID=%s, clientID=%s", name, uaID, *uaIdentity.PrincipalID, clientID)
-					identities = append(identities, NodeIdentityInfo{PrincipalID: *uaIdentity.PrincipalID, ClientID: clientID})
+					identities = append(identities, NodeIdentityInfo{PrincipalID: *uaIdentity.PrincipalID, ClientID: clientID, ResourceID: uaID})
 				}
 			}
 		}
@@ -250,7 +258,7 @@ func (az *Client) GetNodeIdentityInfo(ctx context.Context, resourceGroup string)
 						clientID = *uaIdentity.ClientID
 					}
 					log.Printf("VM %s: found user-assigned identity %s, principalID=%s, clientID=%s", name, uaID, *uaIdentity.PrincipalID, clientID)
-					identities = append(identities, NodeIdentityInfo{PrincipalID: *uaIdentity.PrincipalID, ClientID: clientID})
+					identities = append(identities, NodeIdentityInfo{PrincipalID: *uaIdentity.PrincipalID, ClientID: clientID, ResourceID: uaID})
 				}
 			}
 		}
@@ -331,4 +339,34 @@ func (az *Client) EnsureNodeStorageBlobDataRole(ctx context.Context, resourceGro
 		log.Printf("Successfully assigned Storage Blob Data Contributor role to all %d node identities and found client ID %s", len(identities), firstClientID)
 	}
 	return firstClientID, nil
+}
+
+// GetFirstUserAssignedIdentity returns the first user-assigned identity with both clientID and principalID.
+func (az *Client) GetFirstUserAssignedIdentity(ctx context.Context, resourceGroup string) (*NodeIdentityInfo, error) {
+	identities, err := az.GetNodeIdentityInfo(ctx, resourceGroup)
+	if err != nil {
+		return nil, err
+	}
+	for i := range identities {
+		if identities[i].ClientID != "" && identities[i].PrincipalID != "" && identities[i].ResourceID != "" {
+			return &identities[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no user-assigned identity with clientID, principalID, and resourceID found in resource group %s", resourceGroup)
+}
+
+// CreateFederatedIdentityCredential creates or updates a federated identity credential
+// for workload identity authentication.
+func (az *Client) CreateFederatedIdentityCredential(ctx context.Context, identityRG, identityName, ficName, issuerURL, subject string) error {
+	_, err := az.ficClient.CreateOrUpdate(ctx, identityRG, identityName, ficName, armmsi.FederatedIdentityCredential{
+		Properties: &armmsi.FederatedIdentityCredentialProperties{
+			Issuer:    to.Ptr(issuerURL),
+			Subject:   to.Ptr(subject),
+			Audiences: []*string{to.Ptr("api://AzureADTokenExchange")},
+		},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create/update federated identity credential %s: %w", ficName, err)
+	}
+	return nil
 }


### PR DESCRIPTION
## What type of PR is this?
/kind test

## What this PR does / why we need it
Adds an e2e test for blob dynamic provisioning with workload identity token mount (`mountWithWorkloadIdentityToken`), following the same pattern as kubernetes-sigs/azurefile-csi-driver#3118.

### Changes:
1. **`test/utils/azure/azure_helper.go`**:
   - Added `ResourceID` field to `NodeIdentityInfo` struct
   - Added `ficClient` (FederatedIdentityCredentials client) to `Client`
   - Added `GetFirstUserAssignedIdentity()` — returns the first user-assigned identity with clientID, principalID, and resourceID
   - Added `CreateFederatedIdentityCredential()` — creates/updates a federated identity credential for WI authentication

2. **`test/e2e/suite_test.go`**:
   - Added workload identity setup in `SynchronizedBeforeSuite` (CAPZ only):
     - Discovers OIDC issuer URL from kube-apiserver `/.well-known/openid-configuration`
     - Gets node user-assigned identity info
     - Creates federated identity credential binding the identity to a K8s service account
     - Creates/updates the service account with `azure.workload.identity/*` labels and annotations
     - Assigns Storage Blob Data Contributor role to the identity
   - Added CAPZ OIDC JWKS key mismatch detection and auto-repair (see below)
   - Background AAD token exchange warm-up runs in parallel with other tests

3. **`test/e2e/dynamic_provisioning_test.go`**: New test case — creates a volume with `mountWithWorkloadIdentityToken=true` StorageClass (`Premium_LRS`, `fuse2` protocol) using a WI-annotated service account, runs in `default` namespace (required for FIC subject binding)

4. **`test/e2e/testsuites/`**:
   - Added `ServiceAccountName` field to `DynamicallyProvisionedCmdVolumeTest`
   - Added `SetServiceAccountName()` and `SetAutomountServiceAccountToken()` to `TestPod`

5. **`go.mod`**: Promoted `armmsi` from indirect to direct dependency

### How it works:
- In CAPZ environments, `BeforeSuite` discovers OIDC issuer, creates FIC + service account + role assignment
- The test creates a StorageClass with `mountWithWorkloadIdentityToken=true` and verifies dynamic provisioning + pod mount works using the WI-annotated service account
- Skipped on non-CAPZ clusters; fails with a clear error if WI setup or warm-up failed

### CAPZ OIDC JWKS Key Mismatch Fix

During investigation, we discovered that CAPZ clusters have a race condition during bootstrap: the JWKS uploaded to Azure Blob Storage (`$web` container) can contain a different signing key than what kube-apiserver actually uses to sign ServiceAccount tokens. This causes AAD to permanently reject token exchanges with `AADSTS7000272` ("certificate could not be found in the metadata of identity provider"), regardless of how long you wait.

**Root cause**: The signing key ID (`kid`) in the SA token does not match any key in the OIDC issuer's JWKS document hosted on Azure Blob Storage. This is not an AAD cache delay — it is a key mismatch that will never resolve on its own.

**Fix**: Added `verifyJWKSKeyMatch()` which:
1. Creates a SA token and extracts the `kid` from its JWT header
2. Fetches the JWKS from the OIDC blob URL and compares key IDs
3. If mismatched, fetches the correct JWKS from kube-apiserver (`/openid/v1/jwks`)
4. Re-uploads the corrected JWKS to the blob storage `$web` container

**Result**: After uploading the correct JWKS, AAD token exchange succeeds within 1 second (previously timed out after 45+ minutes of retrying).

### Reference:
- Doc: https://github.com/kubernetes-sigs/blob-csi-driver/blob/master/docs/workload-identity-static-pv-mount.md
- Similar PR for azurefile: kubernetes-sigs/azurefile-csi-driver#3118

## Does this PR introduce a user-facing change?
```release-note
NONE
```
