### PR TITLE
docs: add blobfuse2 crash troubleshooting guide

### DIFF
--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -185,5 +185,20 @@ If IP was migrated successfully, you should find logs like:
 
 </details>
 
+### Troubleshooting Blobfuse2 crash ("transport endpoint not connected")
+> If the issue is related to the Blobfuse2 binary crashing resulting in a `transport endpoint not connected` error:
+
+ - Collect the stack trace file from the node at the following path:
+```console
+ls $HOME/.blobfuse2/*.trace
+```
+> The trace file follows the naming convention `<mount_path>.<pid>.trace`. Share this file for further investigation.
+
+ - If the issue persists, enable debug logging by adding `--log-level=LOG_DEBUG` to the mount command, reproduce the issue, and share the Blobfuse debug level logs:
+```console
+blobfuse2 mount <mount-path> --log-level=LOG_DEBUG --log-file-path=/tmp/blobfuse2-debug.log <other-options>
+```
+> For CSI driver managed mounts, you can enable debug logging by setting `--blobfuse2-args="--log-level=LOG_DEBUG"` in the StorageClass parameters or volume attributes.
+
 ### Tips
  - [Troubleshoot Azure Blob storage mount issues on AKS](http://aka.ms/blobmounterror)

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -199,7 +199,6 @@ If IP was migrated successfully, you should find logs like:
  mountOptions:
    - --log-level=LOG_DEBUG
  ```
- > Refer to [storageclass-blobfuse2.yaml](../deploy/example/storageclass-blobfuse2.yaml) for a complete example.
 
 ### Tips
  - [Troubleshoot Azure Blob storage mount issues on AKS](http://aka.ms/blobmounterror)

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -198,7 +198,12 @@ ls $HOME/.blobfuse2/*.trace
 ```console
 blobfuse2 mount <mount-path> --log-level=LOG_DEBUG --log-file-path=/tmp/blobfuse2-debug.log <other-options>
 ```
-> For CSI driver managed mounts, you can enable debug logging by setting `--blobfuse2-args="--log-level=LOG_DEBUG"` in the StorageClass parameters or volume attributes.
+> For CSI driver managed mounts, you can set `--log-level=LOG_DEBUG` in the StorageClass `mountOptions`:
+> ```yaml
+> mountOptions:
+>   - --log-level=LOG_DEBUG
+> ```
+> Refer to [storageclass-blobfuse2.yaml](../deploy/example/storageclass-blobfuse2.yaml) for a complete example.
 
 ### Tips
  - [Troubleshoot Azure Blob storage mount issues on AKS](http://aka.ms/blobmounterror)

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -188,11 +188,11 @@ If IP was migrated successfully, you should find logs like:
 ### Troubleshooting Blobfuse2 crash ("transport endpoint not connected")
 > If the issue is related to the Blobfuse2 binary crashing resulting in a `transport endpoint not connected` error:
 
- - Collect the stack trace file from the node at the following path:
+ - Collect the crash stack trace files from the `$HOME/.blobfuse2/` directory on the node. Multiple trace files may exist if there were multiple crashes:
 ```console
 ls $HOME/.blobfuse2/*.trace
 ```
-> The trace file follows the naming convention `<mount_path>.<pid>.trace`. Share this file for further investigation.
+> Each trace file follows the naming convention `<mount-path>.<pid>.trace`. Share the relevant trace file(s) for further investigation.
 
  - If the issue persists, enable debug logging by setting `--log-level=LOG_DEBUG` in the `mountOptions` of Persistent Volume, reproduce the issue, and share the Blobfuse debug level logs:
 ```yaml

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -189,17 +189,17 @@ If IP was migrated successfully, you should find logs like:
 > If the issue is related to the Blobfuse2 binary crashing resulting in a `transport endpoint not connected` error:
 
  - Collect the crash stack trace files from the `$HOME/.blobfuse2/` directory on the node. Multiple trace files may exist if there were multiple crashes:
-```console
-ls $HOME/.blobfuse2/*.trace
-```
-> Each trace file follows the naming convention `<mount-path>.<pid>.trace`. Share the relevant trace file(s) for further investigation.
+ ```console
+ ls $HOME/.blobfuse2/*.trace
+ ```
+ > Each trace file follows the naming convention `<mount-path>.<pid>.trace`. Share the relevant trace file(s) for further investigation.
 
  - If the issue persists, enable debug logging by setting `--log-level=LOG_DEBUG` in the `mountOptions` of Persistent Volume, reproduce the issue, and share the Blobfuse debug level logs:
-```yaml
-mountOptions:
-  - --log-level=LOG_DEBUG
-```
-> Refer to [storageclass-blobfuse2.yaml](../deploy/example/storageclass-blobfuse2.yaml) for a complete example.
+ ```yaml
+ mountOptions:
+   - --log-level=LOG_DEBUG
+ ```
+ > Refer to [storageclass-blobfuse2.yaml](../deploy/example/storageclass-blobfuse2.yaml) for a complete example.
 
 ### Tips
  - [Troubleshoot Azure Blob storage mount issues on AKS](http://aka.ms/blobmounterror)

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -194,7 +194,7 @@ If IP was migrated successfully, you should find logs like:
  ```
  > Each trace file follows the naming convention `<mount-path>.<pid>.trace`. Share the relevant trace file(s) for further investigation.
 
- - If the issue persists, enable debug logging by setting `--log-level=LOG_DEBUG` in the `mountOptions` of Persistent Volume, reproduce the issue, and share the Blobfuse debug level logs:
+ - If the issue persists, enable Blobfuse2 debug logging by setting `--log-level=LOG_DEBUG` in `mountOptions` of the StorageClass (dynamic provisioning) or Persistent Volume (static provisioning), reproduce the issue, and share the debug logs:
  ```yaml
  mountOptions:
    - --log-level=LOG_DEBUG

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -194,15 +194,11 @@ ls $HOME/.blobfuse2/*.trace
 ```
 > The trace file follows the naming convention `<mount_path>.<pid>.trace`. Share this file for further investigation.
 
- - If the issue persists, enable debug logging by adding `--log-level=LOG_DEBUG` to the mount command, reproduce the issue, and share the Blobfuse debug level logs:
-```console
-blobfuse2 mount <mount-path> --log-level=LOG_DEBUG --log-file-path=/tmp/blobfuse2-debug.log <other-options>
+ - If the issue persists, enable debug logging by setting `--log-level=LOG_DEBUG` in the StorageClass `mountOptions`, reproduce the issue, and share the Blobfuse debug level logs:
+```yaml
+mountOptions:
+  - --log-level=LOG_DEBUG
 ```
-> For CSI driver managed mounts, you can set `--log-level=LOG_DEBUG` in the StorageClass `mountOptions`:
-> ```yaml
-> mountOptions:
->   - --log-level=LOG_DEBUG
-> ```
 > Refer to [storageclass-blobfuse2.yaml](../deploy/example/storageclass-blobfuse2.yaml) for a complete example.
 
 ### Tips

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -194,7 +194,7 @@ ls $HOME/.blobfuse2/*.trace
 ```
 > The trace file follows the naming convention `<mount_path>.<pid>.trace`. Share this file for further investigation.
 
- - If the issue persists, enable debug logging by setting `--log-level=LOG_DEBUG` in the StorageClass `mountOptions`, reproduce the issue, and share the Blobfuse debug level logs:
+ - If the issue persists, enable debug logging by setting `--log-level=LOG_DEBUG` in the `mountOptions` of Persistent Volume, reproduce the issue, and share the Blobfuse debug level logs:
 ```yaml
 mountOptions:
   - --log-level=LOG_DEBUG


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it
Adds troubleshooting steps for Blobfuse2 binary crash that results in `transport endpoint not connected` error:

1. **Stack trace collection** — crash trace files can be found at `$HOME/.blobfuse2/<mount_path>.<pid>.trace` on the node
2. **Debug logging** — enable `--log-level=LOG_DEBUG` in the mount command to capture detailed Blobfuse logs for investigation

## Does this PR introduce a user-facing change?
```release-note
NONE
```