### PR TITLE
ci: declare contents: read on the 8 remaining workflows

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,9 @@
 # https://github.com/codespell-project/codespell
 name: codespell
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -2,6 +2,9 @@ name: MacOS Build & Unit Test
 on:
     pull_request: {}
     push: {}
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -3,6 +3,9 @@ on:
     pull_request: {}
     push: {}
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/pluto.yaml
+++ b/.github/workflows/pluto.yaml
@@ -3,6 +3,9 @@ on:
     pull_request: {}
     push: {}
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -11,6 +11,9 @@ on:
       - master
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -2,6 +2,9 @@ name: Static Checks
 on:
     pull_request: {}
     push: {}
+permissions:
+  contents: read
+
 jobs:
     go_lint:
         name: Go Lint

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,6 +2,9 @@ name: Windows Tests
 on:
     pull_request: {}
     push: {}
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only on the eight workflows still inheriting org defaults. All eight are read-only:

- `codespell.yml` — `codespell-project/actions-codespell`.
- `darwin.yaml` / `linux.yaml` / `windows.yaml` — go build + unit tests.
- `pluto.yaml` — `FairwindsOps/pluto` checks for deprecated/removed Kubernetes APIs in `deploy/`.
- `shellcheck.yaml` — runs ShellCheck.
- `static.yaml` — golangci-lint matrix.
- `trivy.yaml` — builds a local image and runs trivy with `format: table` (no SARIF upload, so no `security-events: write` needed).

YAML validated locally.