### PR TITLE
Fix/blobfuse proxy context

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -166,7 +166,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (d *Driver) mountBlobfuseWithProxy(args, protocol string, authEnv []string) (string, error) {
+func (d *Driver) mountBlobfuseWithProxy(ctx context.Context, args, protocol string, authEnv []string) (string, error) {
 	mc := csiMetrics.NewCSIMetricContext("node_blobfuse_proxy_mount")
 	isOperationSucceeded := false
 	defer func() {
@@ -174,10 +174,10 @@ func (d *Driver) mountBlobfuseWithProxy(args, protocol string, authEnv []string)
 	}()
 
 	connectionTimeout := time.Duration(d.blobfuseProxyConnTimeout) * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
-	defer cancel()
+	dialCtx, dialCancel := context.WithTimeout(ctx, connectionTimeout)
+	defer dialCancel()
 	klog.V(2).Infof("start connecting to blobfuse proxy, protocol: %s, args: %s", protocol, args)
-	conn, err := grpc.DialContext(ctx, d.blobfuseProxyEndpoint, grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.DialContext(dialCtx, d.blobfuseProxyEndpoint, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		klog.Errorf("failed to connect to blobfuse proxy: %v", err)
 		return "", err
@@ -195,7 +195,7 @@ func (d *Driver) mountBlobfuseWithProxy(args, protocol string, authEnv []string)
 		AuthEnv:   authEnv,
 	}
 	klog.V(2).Infof("begin to mount with blobfuse proxy, protocol: %s, args: %s", protocol, args)
-	resp, err := mountClient.service.MountAzureBlob(context.TODO(), &mountreq)
+	resp, err := mountClient.service.MountAzureBlob(ctx, &mountreq)
 	if err != nil {
 		klog.Error("GRPC call returned with an error:", err)
 	}
@@ -491,7 +491,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	var output string
 	if d.enableBlobfuseProxy {
-		output, err = d.mountBlobfuseWithProxy(args, protocol, authEnv)
+		output, err = d.mountBlobfuseWithProxy(ctx, args, protocol, authEnv)
 	} else {
 		output, err = d.mountBlobfuseInsideDriver(args, protocol, authEnv)
 	}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -1160,6 +1160,78 @@ func TestMountBlobfuseWithProxy(t *testing.T) {
 	}
 }
 
+// blockingMountServiceServer blocks in MountAzureBlob until the request
+// context is cancelled, so we can verify caller-side cancellation is
+// propagated through to the gRPC call.
+type blockingMountServiceServer struct {
+	mount_azure_blob.MountServiceServer
+	started chan struct{}
+}
+
+func (s *blockingMountServiceServer) MountAzureBlob(ctx context.Context, _ *mount_azure_blob.MountAzureBlobRequest) (*mount_azure_blob.MountAzureBlobResponse, error) {
+	close(s.started)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestMountBlobfuseWithProxy_ContextCancellation verifies that cancelling
+// the context passed into mountBlobfuseWithProxy propagates to the
+// MountAzureBlob gRPC call. Without context propagation the call would
+// run until blobfuseProxyConnTimeout (which previously only applied to
+// the dial, not to the RPC), so a hung proxy would block indefinitely.
+func TestMountBlobfuseWithProxy_ContextCancellation(t *testing.T) {
+	srv := &blockingMountServiceServer{started: make(chan struct{})}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	s := grpc.NewServer()
+	mount_azure_blob.RegisterMountServiceServer(s, srv)
+	go func() {
+		if err := s.Serve(lis); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			t.Logf("server exited with error: %v", err)
+		}
+	}()
+	defer s.Stop()
+	defer lis.Close()
+
+	d := NewFakeDriver()
+	d.blobfuseProxyEndpoint = lis.Addr().String()
+	// Generous dial timeout so the test fails on missing cancellation,
+	// not on the dial deadline expiring.
+	d.blobfuseProxyConnTimeout = 30
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.mountBlobfuseWithProxy(ctx, "--tmp-path /tmp", Fuse, []string{"username=blob"})
+		done <- err
+	}()
+
+	// Wait for the server to enter MountAzureBlob, then cancel.
+	select {
+	case <-srv.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never received MountAzureBlob call")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error from cancelled MountAzureBlob, got nil")
+		}
+		if !strings.Contains(err.Error(), "Canceled") && !strings.Contains(err.Error(), "canceled") {
+			t.Fatalf("expected context-cancelled error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("mountBlobfuseWithProxy did not return after context cancellation")
+	}
+}
+
 func TestMountBlobfuseInsideDriver(t *testing.T) {
 	args := "--tmp-path /tmp"
 	authEnv := []string{"username=blob", "authkey=blob"}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -1150,7 +1150,7 @@ func TestMountBlobfuseWithProxy(t *testing.T) {
 			}
 
 			// Run the test - call mountBlobfuseWithProxy directly
-			output, err := d.mountBlobfuseWithProxy(test.args, test.protocol, test.authEnv)
+			output, err := d.mountBlobfuseWithProxy(context.Background(), test.args, test.protocol, test.authEnv)
 
 			// Verify results
 			if test.cleanupCheck != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

Thread context through mountBlobfuseWithProxy

mountBlobfuseWithProxy invoked the blobfuse-proxy MountAzureBlob gRPC call with context.TODO(). A kubelet-driven cancellation could not interrupt a hung mount, and there was nothing to bound a stuck MountAzureBlob RPC.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
