### PR TITLE
test: only enable serviceAccountTokenInSecrets test in pull-blob-csi-driver-e2e-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ CSI_IMAGE_TAG ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 CSI_IMAGE_TAG_LATEST = $(REGISTRY)/$(IMAGE_NAME):latest
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS ?= "-X ${PKG}/pkg/blob.driverVersion=${IMAGE_VERSION} -X ${PKG}/pkg/blob.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/blob.buildDate=${BUILD_DATE} -s -w -extldflags '-static'"
-E2E_HELM_OPTIONS ?= --set image.blob.pullPolicy=Always --set image.blob.repository=$(REGISTRY)/$(IMAGE_NAME) --set image.blob.tag=$(IMAGE_VERSION) --set driver.userAgentSuffix="e2e-test" --set controller.runOnControlPlane=true --set feature.serviceAccountTokenInSecrets=true
+E2E_HELM_OPTIONS ?= --set image.blob.pullPolicy=Always --set image.blob.repository=$(REGISTRY)/$(IMAGE_NAME) --set image.blob.tag=$(IMAGE_VERSION) --set driver.userAgentSuffix="e2e-test" --set controller.runOnControlPlane=true
 ifdef ENABLE_BLOBFUSE_PROXY
-E2E_HELM_OPTIONS += --set node.enableBlobfuseProxy=true --set image.blob.pullPolicy=Always --set controller.logLevel=6 --set node.logLevel=6
+E2E_HELM_OPTIONS += --set node.enableBlobfuseProxy=true --set image.blob.pullPolicy=Always --set controller.logLevel=6 --set node.logLevel=6 --set feature.serviceAccountTokenInSecrets=true
 endif
 E2E_HELM_OPTIONS += ${EXTRA_HELM_OPTIONS}
 GO111MODULE = on


### PR DESCRIPTION
Move `--set feature.serviceAccountTokenInSecrets=true` from the base `E2E_HELM_OPTIONS` to the `ENABLE_BLOBFUSE_PROXY` block, since this feature is only needed when blobfuse proxy is enabled.