### PR TITLE
[release-1.26] fix: harden ephemeral mount option handling for inline volumes (cherry-pick #2460)

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -23,10 +23,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	azstorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -172,7 +174,115 @@ var (
 
 	// azcopyCloneVolumeOptions used in volume cloning between different storage account and --check-length to false because volume data may be in changing state, copy volume is not same as current source volume,
 	// set --s2s-preserve-access-tier=false to avoid BlobAccessTierNotSupportedForAccountType error in azcopy
-	azcopyCloneVolumeOptions = []string{"--recursive", "--check-length=false", "--s2s-preserve-access-tier=false", "--log-level=ERROR"}
+	azcopyCloneVolumeOptions  = []string{"--recursive", "--check-length=false", "--s2s-preserve-access-tier=false", "--log-level=ERROR"}
+	defaultAzureOAuthTokenDir = "/var/lib/kubelet/plugins/" + DefaultDriverName
+
+	// containerNameRegex enforces Azure Blob Storage container naming rules.
+	// Names containing spaces or special characters cannot match and are
+	// rejected before reaching the blobfuse2 args string.
+	containerNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$`)
+
+	// allowedEphemeralMountOptions is the allowlist of blobfuse2 CLI flags that
+	// may appear in volumeAttributes.mountOptions for an ephemeral inline volume.
+	// Any flag NOT in this map is rejected by SanitizeMountOptions.
+	//
+	// Verified against: blobfuse2 mount --help (v2.x)
+	//
+	// Intentionally absent (must remain driver-controlled):
+	//   --tmp-path          — redirects file-cache root to arbitrary host path
+	//   --block-cache-path  — same primitive for block-cache mode
+	//   --config-file       — loads arbitrary blobfuse2 config from host
+	//   --log-file-path     — root-owned log writes to arbitrary host path
+	//   --container-name    — driver sets this from the validated containerName
+	//                         volumeAttribute; allowing it in mountOptions would
+	//                         override that validation entirely
+	//   --passphrase        — decrypts --secure-config files; enables config-file
+	//                         attack path indirectly
+	//   --secure-config     — enables encrypted config loading; combined with
+	//                         --passphrase reinstates the --config-file attack
+	//
+	// Note: FUSE passthrough tokens "-o <option>[=value]" are always permitted;
+	// they are handled separately in SanitizeMountOptions.
+	allowedEphemeralMountOptions = map[string]struct{}{
+		"--allow-other":                    {},
+		"--attr-cache-timeout":             {},
+		"--attr-timeout":                   {},
+		"--block-cache":                    {},
+		"--block-cache-block-size":         {},
+		"--block-cache-disk-size":          {},
+		"--block-cache-disk-timeout":       {},
+		"--block-cache-parallelism":        {},
+		"--block-cache-pool-size":          {},
+		"--block-cache-prefetch":           {},
+		"--block-cache-prefetch-on-open":   {},
+		"--block-cache-strong-consistency": {},
+		"--block-size-mb":                  {},
+		"--cache-size-mb":                  {},
+		"--cap-iops":                       {},
+		"--cap-mbps-read":                  {},
+		"--cleanup-on-start":               {},
+		"--cpk-enabled":                    {},
+		"--disable-compression":            {},
+		"--disable-kernel-cache":           {},
+		"--disable-version-check":          {},
+		"--disable-writeback-cache":        {},
+		"--cancel-list-on-mount-seconds":   {},
+		"--entry-timeout":                  {},
+		"--file-cache-timeout":             {},
+		"--file-cache-timeout-in-seconds":  {},
+		"--filter":                         {},
+		"--foreground":                     {},
+		"--hard-limit":                     {},
+		"--high-disk-threshold":            {},
+		"--ignore-open-flags":              {},
+		"--ignore-sync":                    {},
+		"--list-cache-timeout":             {},
+		"--log-goroutine-id":               {},
+		"--log-level":                      {},
+		"--log-type":                       {},
+		"--low-disk-threshold":             {},
+		"--negative-timeout":               {},
+		"--no-symlinks":                    {},
+		"--pool-size":                      {},
+		"--preload":                        {},
+		"--preserve-acl":                   {},
+		"--read-only":                      {},
+		"--subdirectory":                   {},
+		"--sync-to-flush":                  {},
+		"--use-attr-cache":                 {},
+		"--virtual-directory":              {},
+		"--wait-for-mount":                 {},
+		"--workers":                        {},
+	}
+
+	// allowedLogLevels is the set of valid values for the --log-level flag.
+	// Source: blobfuse2 mount --help and shell-completion list.
+	allowedLogLevels = map[string]struct{}{
+		"LOG_OFF":     {},
+		"LOG_CRIT":    {},
+		"LOG_ERR":     {},
+		"LOG_WARNING": {},
+		"LOG_INFO":    {},
+		"LOG_TRACE":   {},
+		"LOG_DEBUG":   {},
+	}
+
+	// allowedLogTypes is the set of valid values for the --log-type flag.
+	// Source: blobfuse2 mount --help.
+	allowedLogTypes = map[string]struct{}{
+		"silent": {},
+		"syslog": {},
+		"base":   {},
+	}
+
+	// subdirectoryRegex matches valid Azure blob path prefixes: alphanumerics,
+	// hyphens, underscores, dots, and forward slashes. Spaces and other
+	// characters that could interfere with arg parsing are excluded.
+	subdirectoryRegex = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
+
+	// filterRegex matches valid blobfuse2 blob-filter patterns: alphanumerics,
+	// hyphens, underscores, dots, forward slashes, and glob wildcards (* ?).
+	filterRegex = regexp.MustCompile(`^[a-zA-Z0-9._/*?-]+$`)
 )
 
 // DriverOptions defines driver parameters specified in driver deployment
@@ -1074,6 +1184,184 @@ func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName stri
 	return false
 }
 
+// ValidateMountArgValues checks that no value in the mountOptions slice contains
+// whitespace. Whitespace inside a value would be misinterpreted as a flag
+// separator by the blobfuse-proxy or blobfuse2's own argument parser. This
+// check is a last-resort safety net applied after all other validations
+// (SanitizeMountOptions, ValidateContainerName) and after
+// appendDefaultMountOptions has added driver-controlled defaults.
+func ValidateMountArgValues(mountOptions []string) error {
+	for _, opt := range mountOptions {
+		// Split on the first "=" to isolate the value.
+		parts := strings.SplitN(strings.TrimSpace(opt), "=", 2)
+		if len(parts) == 2 && strings.IndexFunc(parts[1], unicode.IsSpace) >= 0 {
+			return fmt.Errorf("mount option %q has an invalid value: whitespace is not permitted", parts[0])
+		}
+	}
+	return nil
+}
+
+// ValidateContainerName rejects any containerName that does not conform to
+// Azure Blob Storage naming rules. Because the regex only permits lowercase
+// alphanumeric characters and hyphens, names containing spaces or other special
+// characters are rejected before the value is included in the blobfuse2 args
+// string that the proxy splits on whitespace.
+func ValidateContainerName(containerName string) error {
+	// Empty is allowed: some flows (e.g. workload identity) resolve the container
+	// name later; an empty value cannot inject any arguments.
+	if containerName == "" {
+		return nil
+	}
+	if !containerNameRegex.MatchString(containerName) {
+		return fmt.Errorf("invalid containerName %q: must be 3–63 lowercase alphanumeric/hyphen characters, "+
+			"start and end with a letter or digit, and contain no consecutive hyphens", containerName)
+	}
+	if strings.Contains(containerName, "--") {
+		return fmt.Errorf("invalid containerName %q: consecutive hyphens are not allowed", containerName)
+	}
+	return nil
+}
+
+// tokenizeMountOptionsString splits a mountOptions string from volumeAttributes
+// into individual option tokens. It supports two formats:
+//
+//   - Comma-separated: "--log-level=LOG_WARNING,--cache-size-mb=100,-o allow_other"
+//   - Space-separated: "-o allow_other --file-cache-timeout-in-seconds=240"
+//
+// When the string contains no comma the space-separated path is used. In that
+// case "-o FUSE_OPT" pairs (where the FUSE option is the token immediately
+// following "-o") are kept as a single element so they satisfy the form
+// expected by SanitizeMountOptions.
+func tokenizeMountOptionsString(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if strings.Contains(s, ",") {
+		// Comma-separated format: trim each token and reject any token that
+		// contains internal whitespace. TrimSpace only strips leading/trailing
+		// whitespace; a tab or newline embedded inside a value (e.g.
+		// "--cache-size-mb=512\t--tmp-path=/etc") would survive and reach the
+		// validators as a single token, bypassing the per-flag checks.
+		//
+		// Exception: the single space in a valid "-o <value>" token is expected
+		// (SanitizeMountOptions validates the value part separately).
+		var tokens []string
+		for _, t := range strings.Split(s, ",") {
+			if t = strings.TrimSpace(t); t != "" {
+				if strings.HasPrefix(t, "-o ") {
+					// The space between "-o" and its value is expected; reject
+					// any further whitespace embedded in the value part.
+					if strings.IndexFunc(t[3:], unicode.IsSpace) >= 0 {
+						return []string{t}
+					}
+				} else if strings.IndexFunc(t, unicode.IsSpace) >= 0 {
+					return []string{t}
+				}
+				tokens = append(tokens, t)
+			}
+		}
+		return tokens
+	}
+	// Space-separated format: reassemble "-o FUSE_OPT" pairs so that each
+	// "-o" and its argument are kept as one element ("-o allow_other").
+	fields := strings.Fields(s)
+	tokens := make([]string, 0, len(fields))
+	for i := 0; i < len(fields); i++ {
+		if fields[i] == "-o" && i+1 < len(fields) {
+			tokens = append(tokens, "-o "+fields[i+1])
+			i++
+		} else {
+			tokens = append(tokens, fields[i])
+		}
+	}
+	return tokens
+}
+
+// SanitizeMountOptions validates that every blobfuse2 flag in mountOptions
+// appears in the allowedEphemeralMountOptions allowlist. It is called only for
+// ephemeral inline volumes where volumeAttributes.mountOptions is user-supplied.
+// FUSE passthrough tokens ("-o <option>") are always permitted.
+func SanitizeMountOptions(mountOptions []string) ([]string, error) {
+	sanitized := make([]string, 0, len(mountOptions))
+	for _, opt := range mountOptions {
+		trimmed := strings.TrimSpace(opt)
+		// Skip empty entries (e.g. from splitting an empty mountOptions string).
+		if trimmed == "" {
+			continue
+		}
+		// "-o <fuse_option>[=value]" tokens are FUSE passthrough options handled
+		// by the kernel mount layer; they do not redirect host paths.
+		// A bare "-o" with no FUSE option value is always invalid: the proxy
+		// joins all tokens with spaces, so "-o" at the end of the user slice
+		// would consume the next driver-controlled flag as its argument.
+		if trimmed == "-o" {
+			return nil, fmt.Errorf("mount option \"-o\" requires a FUSE option value")
+		}
+		if strings.HasPrefix(trimmed, "-o ") {
+			// Reject if the FUSE option value contains any whitespace. The proxy
+			// splits the flat args string on spaces; any whitespace character
+			// (tab, LF, CR, FF) that survives is normalised to a space by
+			// TrimDuplicatedSpace before the split, producing injected argv elements.
+			rest := strings.TrimSpace(trimmed[3:])
+			if strings.IndexFunc(rest, unicode.IsSpace) >= 0 {
+				return nil, fmt.Errorf("mount option %q: FUSE -o options must not contain whitespace", trimmed)
+			}
+			// FUSE -o options (allow_other, ro, rw, umask=…, uid=…, …) never start
+			// with "-". A leading "-" means the user is smuggling a blobfuse2 CLI
+			// flag through the passthrough, which the proxy will hand to blobfuse2
+			// as a top-level argument after splitting on whitespace.
+			if strings.HasPrefix(rest, "-") {
+				return nil, fmt.Errorf("mount option %q: -o values must be FUSE options, not CLI flags", trimmed)
+			}
+			sanitized = append(sanitized, trimmed)
+			continue
+		}
+		// Extract the flag name: the part before "=" (or the whole token if no "=").
+		parts := strings.SplitN(trimmed, "=", 2)
+		flagName := parts[0]
+		if _, ok := allowedEphemeralMountOptions[flagName]; !ok {
+			return nil, fmt.Errorf("mount option %q is not allowed for ephemeral volumes", flagName)
+		}
+		// Validate enum-typed flags when a value is present.
+		if len(parts) == 2 {
+			flagValue := parts[1]
+			// Reject any whitespace in the value. The proxy joins all tokens
+			// with single spaces and then splits on " " to build argv; any
+			// whitespace surviving inside a value (e.g. "--cache-size-mb=512,-o --config-file=/tmp/x")
+			// is normalised to a space by TrimDuplicatedSpace and split off
+			// into an injected argv element (here: "--config-file=/tmp/x").
+			if strings.IndexFunc(flagValue, unicode.IsSpace) >= 0 {
+				return nil, fmt.Errorf("mount option %q: value must not contain whitespace", trimmed)
+			}
+			switch flagName {
+			case "--log-level":
+				if _, ok := allowedLogLevels[flagValue]; !ok {
+					return nil, fmt.Errorf("mount option --log-level has invalid value %q: "+
+						"allowed values are LOG_OFF, LOG_CRIT, LOG_ERR, LOG_WARNING, LOG_INFO, LOG_TRACE, LOG_DEBUG", flagValue)
+				}
+			case "--log-type":
+				if _, ok := allowedLogTypes[flagValue]; !ok {
+					return nil, fmt.Errorf("mount option --log-type has invalid value %q: "+
+						"allowed values are silent, syslog, base", flagValue)
+				}
+			case "--subdirectory":
+				if !subdirectoryRegex.MatchString(flagValue) {
+					return nil, fmt.Errorf("mount option --subdirectory has invalid value %q: "+
+						"only alphanumerics, hyphens, underscores, dots, and slashes are permitted", flagValue)
+				}
+			case "--filter":
+				if !filterRegex.MatchString(flagValue) {
+					return nil, fmt.Errorf("mount option --filter has invalid value %q: "+
+						"only alphanumerics, hyphens, underscores, dots, slashes, and glob wildcards (* ?) are permitted", flagValue)
+				}
+			}
+		}
+		sanitized = append(sanitized, trimmed)
+	}
+	return sanitized, nil
+}
+
 // appendDefaultMountOptions return mount options combined with mountOptions and defaultMountOptions
 func appendDefaultMountOptions(mountOptions []string, tmpPath, containerName string) []string {
 	var defaultMountOptions = map[string]string{
@@ -1101,13 +1389,19 @@ func appendDefaultMountOptions(mountOptions []string, tmpPath, containerName str
 	allMountOptions := mountOptions
 
 	for k, v := range defaultMountOptions {
-		if _, isIncluded := included[k]; !isIncluded {
-			if v != "" {
-				allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", k, v))
-			} else {
-				allMountOptions = append(allMountOptions, k)
-			}
+		if included[k] {
+			continue
 		}
+		if v == "" {
+			// Defensive: a bare default flag would consume the next argv element
+			// as its value when blobfuse2 parses the split args string. None of
+			// the current defaults legitimately use empty values; if a future
+			// default needs a bare flag, move it to a separate boolean-flags
+			// slice rather than going through this map.
+			klog.Warningf("skipping default mount option %q with empty value", k)
+			continue
+		}
+		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", k, v))
 	}
 
 	return allMountOptions

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1450,6 +1450,678 @@ func TestUseDataPlaneAPI(t *testing.T) {
 	}
 }
 
+func TestTokenizeMountOptionsString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string returns nil",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "whitespace-only returns nil",
+			input:    "   ",
+			expected: nil,
+		},
+		// Comma-separated format
+		{
+			name:     "comma-separated flags",
+			input:    "--log-level=LOG_WARNING,--cache-size-mb=100",
+			expected: []string{"--log-level=LOG_WARNING", "--cache-size-mb=100"},
+		},
+		{
+			name:     "comma-separated with -o token",
+			input:    "-o allow_other,--file-cache-timeout-in-seconds=120",
+			expected: []string{"-o allow_other", "--file-cache-timeout-in-seconds=120"},
+		},
+		{
+			name:     "comma-separated trims spaces around tokens",
+			input:    "--log-level=LOG_WARNING, --cache-size-mb=100",
+			expected: []string{"--log-level=LOG_WARNING", "--cache-size-mb=100"},
+		},
+		{
+			name:     "comma-separated skips empty tokens",
+			input:    "--log-level=LOG_WARNING,,--cache-size-mb=100",
+			expected: []string{"--log-level=LOG_WARNING", "--cache-size-mb=100"},
+		},
+		// Space-separated format (the pre-existing format users had before comma support)
+		{
+			name:     "space-separated reassembles -o pair",
+			input:    "-o allow_other --file-cache-timeout-in-seconds=240",
+			expected: []string{"-o allow_other", "--file-cache-timeout-in-seconds=240"},
+		},
+		{
+			name:     "space-separated single flag",
+			input:    "--log-level=LOG_WARNING",
+			expected: []string{"--log-level=LOG_WARNING"},
+		},
+		{
+			name:     "space-separated multiple -o pairs",
+			input:    "-o allow_other -o attr_timeout=120 --cache-size-mb=100",
+			expected: []string{"-o allow_other", "-o attr_timeout=120", "--cache-size-mb=100"},
+		},
+		{
+			name:     "trailing -o with no argument is kept as-is",
+			input:    "--log-level=LOG_WARNING -o",
+			expected: []string{"--log-level=LOG_WARNING", "-o"},
+		},
+		{
+			// Bad token is returned as-is so SanitizeMountOptions / ValidateMountArgValues
+			// can produce an explicit InvalidArgument error rather than silently dropping input.
+			name:     "comma-separated token with internal tab returns the bad token",
+			input:    "--cache-size-mb=512\t--tmp-path=/etc,--log-level=LOG_WARNING",
+			expected: []string{"--cache-size-mb=512\t--tmp-path=/etc"},
+		},
+		{
+			name:     "comma-separated token with internal newline returns the bad token",
+			input:    "--log-level=LOG_WARNING,--cache-size-mb=512\n--tmp-path=/etc",
+			expected: []string{"--cache-size-mb=512\n--tmp-path=/etc"},
+		},
+		{
+			name:     "comma token with internal CR returns bad token",
+			input:    "--cache-size-mb=512\r--tmp-path=/etc,--read-only",
+			expected: []string{"--cache-size-mb=512\r--tmp-path=/etc"},
+		},
+		{
+			name:     "comma token with internal FF returns bad token",
+			input:    "--cache-size-mb=512\f--tmp-path=/etc,--read-only",
+			expected: []string{"--cache-size-mb=512\f--tmp-path=/etc"},
+		},
+		{
+			name:     "comma token with internal VT returns bad token",
+			input:    "--cache-size-mb=512\v--tmp-path=/etc,--read-only",
+			expected: []string{"--cache-size-mb=512\v--tmp-path=/etc"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := tokenizeMountOptionsString(test.input)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("tokenizeMountOptionsString(%q) = %v, want %v", test.input, result, test.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeMountOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []string
+		wantErr  bool
+		expected []string
+	}{
+		{
+			name:     "allowlisted flag passes through unchanged",
+			options:  []string{"--log-level=LOG_WARNING", "--cache-size-mb=1000"},
+			wantErr:  false,
+			expected: []string{"--log-level=LOG_WARNING", "--cache-size-mb=1000"},
+		},
+		{
+			name:     "-o FUSE passthrough token is always allowed",
+			options:  []string{"-o allow_other", "--log-level=LOG_WARNING"},
+			wantErr:  false,
+			expected: []string{"-o allow_other", "--log-level=LOG_WARNING"},
+		},
+		{
+			name:    "--tmp-path is rejected",
+			options: []string{"--log-level=LOG_WARNING", "--tmp-path=/var/data/cache"},
+			wantErr: true,
+		},
+		{
+			name:    "bare --tmp-path token is rejected (space-separated value)",
+			options: []string{"--tmp-path", "/var/data/cache"},
+			wantErr: true,
+		},
+		{
+			name:    "--block-cache-path is rejected",
+			options: []string{"--block-cache-path=/var/data/cache"},
+			wantErr: true,
+		},
+		{
+			name:    "bare --block-cache-path token is rejected",
+			options: []string{"--block-cache-path", "/var/data/cache"},
+			wantErr: true,
+		},
+		{
+			name:    "--config-file is rejected",
+			options: []string{"--config-file=/var/data/custom.cfg"},
+			wantErr: true,
+		},
+		{
+			name:    "bare --config-file token is rejected",
+			options: []string{"--config-file", "/var/data/custom.cfg"},
+			wantErr: true,
+		},
+		{
+			name:    "--log-file-path is rejected",
+			options: []string{"--log-file-path=/var/log/blobfuse.log"},
+			wantErr: true,
+		},
+		{
+			name:    "--container-name is rejected (driver-controlled)",
+			options: []string{"--container-name=custom-value"},
+			wantErr: true,
+		},
+		{
+			name:    "--passphrase is rejected",
+			options: []string{"--passphrase=secret"},
+			wantErr: true,
+		},
+		{
+			name:    "--secure-config is rejected",
+			options: []string{"--secure-config"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown flag not in allowlist is rejected",
+			options: []string{"--unknown-flag=value"},
+			wantErr: true,
+		},
+		{
+			name:    "first disallowed option in a list causes rejection",
+			options: []string{"--log-level=LOG_WARNING", "--tmp-path=/var/data/cache", "--cache-size-mb=1000"},
+			wantErr: true,
+		},
+		{
+			name:     "empty input returns empty output",
+			options:  []string{},
+			wantErr:  false,
+			expected: []string{},
+		},
+		{
+			name:     "slice with single empty string (from splitting empty mountOptions) is treated as empty",
+			options:  []string{""},
+			wantErr:  false,
+			expected: []string{},
+		},
+		{
+			name:    "option with leading whitespace is still rejected if not allowlisted",
+			options: []string{"--tmp-path=/var/data/cache"},
+			wantErr: true,
+		},
+		// Flags present in official example StorageClass YAMLs that were missing
+		// from the initial allowlist.
+		{
+			name:     "--file-cache-timeout-in-seconds is allowed (used in official SC examples)",
+			options:  []string{"--file-cache-timeout-in-seconds=120"},
+			wantErr:  false,
+			expected: []string{"--file-cache-timeout-in-seconds=120"},
+		},
+		{
+			name:     "--cancel-list-on-mount-seconds is allowed (overrides driver default of 10)",
+			options:  []string{"--cancel-list-on-mount-seconds=60"},
+			wantErr:  false,
+			expected: []string{"--cancel-list-on-mount-seconds=60"},
+		},
+		// -o FUSE passthrough: a space after -o would be treated as additional flags
+		// by the proxy, so the value must be a single token.
+		{
+			name:    "-o option with multiple tokens is rejected",
+			options: []string{"-o allow_other --tmp-path=/var/data/cache"},
+			wantErr: true,
+		},
+		{
+			name:    "-o option with embedded tab is rejected",
+			options: []string{"-o allow_other\t--config-file=/etc/blobfuse.cfg"},
+			wantErr: true,
+		},
+		{
+			name:    "-o option with embedded newline is rejected",
+			options: []string{"-o allow_other\n--config-file=/etc/blobfuse.cfg"},
+			wantErr: true,
+		},
+		{
+			name:    "-o value containing CR is rejected",
+			options: []string{"-o allow_other\rro"},
+			wantErr: true,
+		},
+		{
+			name:    "-o value containing FF is rejected",
+			options: []string{"-o allow_other\fro"},
+			wantErr: true,
+		},
+		{
+			name:    "-o value containing VT is rejected",
+			options: []string{"-o allow_other\vro"},
+			wantErr: true,
+		},
+		{
+			name:     "-o option without extra space is still allowed",
+			options:  []string{"-o allow_other"},
+			wantErr:  false,
+			expected: []string{"-o allow_other"},
+		},
+		{
+			name:     "-o option with =value and no space is still allowed",
+			options:  []string{"-o attr_timeout=120"},
+			wantErr:  false,
+			expected: []string{"-o attr_timeout=120"},
+		},
+		{
+			name:    "bare -o with no FUSE value is rejected",
+			options: []string{"-o"},
+			wantErr: true,
+		},
+		{
+			name:    "bare -o in a list is rejected",
+			options: []string{"--log-level=LOG_WARNING", "-o"},
+			wantErr: true,
+		},
+		// --log-level enum validation
+		{
+			name:     "--log-level=LOG_WARNING is valid",
+			options:  []string{"--log-level=LOG_WARNING"},
+			wantErr:  false,
+			expected: []string{"--log-level=LOG_WARNING"},
+		},
+		{
+			name:     "--log-level=LOG_DEBUG is valid",
+			options:  []string{"--log-level=LOG_DEBUG"},
+			wantErr:  false,
+			expected: []string{"--log-level=LOG_DEBUG"},
+		},
+		{
+			name:     "--log-level=LOG_TRACE is valid",
+			options:  []string{"--log-level=LOG_TRACE"},
+			wantErr:  false,
+			expected: []string{"--log-level=LOG_TRACE"},
+		},
+		{
+			name:    "--log-level with unknown value is rejected",
+			options: []string{"--log-level=VERBOSE"},
+			wantErr: true,
+		},
+		{
+			name:    "--log-level with lowercase value is rejected",
+			options: []string{"--log-level=log_warning"},
+			wantErr: true,
+		},
+		// --log-type enum validation
+		{
+			name:     "--log-type=syslog is valid",
+			options:  []string{"--log-type=syslog"},
+			wantErr:  false,
+			expected: []string{"--log-type=syslog"},
+		},
+		{
+			name:     "--log-type=silent is valid",
+			options:  []string{"--log-type=silent"},
+			wantErr:  false,
+			expected: []string{"--log-type=silent"},
+		},
+		{
+			name:     "--log-type=base is valid",
+			options:  []string{"--log-type=base"},
+			wantErr:  false,
+			expected: []string{"--log-type=base"},
+		},
+		{
+			name:    "--log-type with unknown value is rejected",
+			options: []string{"--log-type=file"},
+			wantErr: true,
+		},
+		// --subdirectory regex validation
+		{
+			name:     "--subdirectory with simple name is valid",
+			options:  []string{"--subdirectory=mydata"},
+			wantErr:  false,
+			expected: []string{"--subdirectory=mydata"},
+		},
+		{
+			name:     "--subdirectory with nested path is valid",
+			options:  []string{"--subdirectory=images/2024/january"},
+			wantErr:  false,
+			expected: []string{"--subdirectory=images/2024/january"},
+		},
+		{
+			name:    "--subdirectory with space in value is rejected",
+			options: []string{"--subdirectory=my folder"},
+			wantErr: true,
+		},
+		{
+			name:    "--subdirectory with shell special chars is rejected",
+			options: []string{"--subdirectory=foo;bar"},
+			wantErr: true,
+		},
+		// --filter regex validation
+		{
+			name:     "--filter with glob wildcard is valid",
+			options:  []string{"--filter=*.txt"},
+			wantErr:  false,
+			expected: []string{"--filter=*.txt"},
+		},
+		{
+			name:     "--filter with path pattern is valid",
+			options:  []string{"--filter=images/*.jpg"},
+			wantErr:  false,
+			expected: []string{"--filter=images/*.jpg"},
+		},
+		{
+			name:    "--filter with space in value is rejected",
+			options: []string{"--filter=foo bar"},
+			wantErr: true,
+		},
+		{
+			name:    "--filter with shell special chars is rejected",
+			options: []string{"--filter=foo;rm -rf /"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --tmp-path",
+			options: []string{"-o --tmp-path"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --config-file",
+			options: []string{"-o --config-file=/tmp/x.yaml"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --passphrase",
+			options: []string{"-o --passphrase=secret"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --container-name",
+			options: []string{"-o --container-name=evil"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --log-file-path",
+			options: []string{"-o --log-file-path=/etc/cron.d/x"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --block-cache-path",
+			options: []string{"-o --block-cache-path=/var/lib/x"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling --secure-config",
+			options: []string{"-o --secure-config"},
+			wantErr: true,
+		},
+		{
+			name:    "rejects -o smuggling via comma carrier",
+			options: []string{"--cache-size-mb=512,-o --config-file=/tmp/x"},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := SanitizeMountOptions(test.options)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("sanitizeMountOptions(%v) expected error, got nil", test.options)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("sanitizeMountOptions(%v) unexpected error: %v", test.options, err)
+				}
+				if !reflect.DeepEqual(result, test.expected) {
+					t.Errorf("sanitizeMountOptions(%v) = %v, want %v", test.options, result, test.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitizeMountOptionsPipeline tests the tokenize→sanitize pipeline that
+// nodeserver.go uses, covering the real-world space-separated format that was
+// broken by the initial security fix.
+func TestSanitizeMountOptionsPipeline(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string // raw volumeAttributes.mountOptions string
+		wantErr     bool
+		expectedLen int // number of tokens in sanitized output (-1 = don't check)
+	}{
+		{
+			name:        "real-world space-separated: -o allow_other + allowlisted flag",
+			input:       "-o allow_other --file-cache-timeout-in-seconds=240",
+			wantErr:     false,
+			expectedLen: 2,
+		},
+		{
+			name:        "real-world comma-separated: same options",
+			input:       "-o allow_other,--file-cache-timeout-in-seconds=240",
+			wantErr:     false,
+			expectedLen: 2,
+		},
+		{
+			name:    "disallowed flag is blocked via space-separated format",
+			input:   "-o allow_other --tmp-path=/var/data/cache",
+			wantErr: true,
+		},
+		{
+			name:    "disallowed flag is blocked via space-separated format (config-file)",
+			input:   "--file-cache-timeout-in-seconds=120 --config-file=/var/data/custom.cfg",
+			wantErr: true,
+		},
+		{
+			name:        "empty string passes",
+			input:       "",
+			wantErr:     false,
+			expectedLen: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tokens := tokenizeMountOptionsString(test.input)
+			result, err := SanitizeMountOptions(tokens)
+			if test.wantErr {
+				if err == nil {
+					t.Errorf("pipeline(%q) expected error, got nil (tokens: %v)", test.input, tokens)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("pipeline(%q) unexpected error: %v (tokens: %v)", test.input, err, tokens)
+				}
+				if test.expectedLen >= 0 && len(result) != test.expectedLen {
+					t.Errorf("pipeline(%q) got %d tokens, want %d: %v", test.input, len(result), test.expectedLen, result)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMountArgValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		wantErr bool
+	}{
+		{
+			name:    "clean options without values pass",
+			options: []string{"--read-only", "--foreground"},
+			wantErr: false,
+		},
+		{
+			name:    "options with values that contain no spaces pass",
+			options: []string{"--log-level=LOG_WARNING", "--cache-size-mb=512"},
+			wantErr: false,
+		},
+		{
+			name:    "empty input passes",
+			options: []string{},
+			wantErr: false,
+		},
+		{
+			name:    "value containing a space is rejected",
+			options: []string{"--subdirectory=foo bar"},
+			wantErr: true,
+		},
+		{
+			name:    "value containing a tab is rejected",
+			options: []string{"--subdirectory=foo\tbar"},
+			wantErr: true,
+		},
+		{
+			name:    "value containing a newline is rejected",
+			options: []string{"--subdirectory=foo\nbar"},
+			wantErr: true,
+		},
+		{
+			name:    "option with space in value is rejected",
+			options: []string{"--subdirectory=mydir --tmp-path=/var/data/cache"},
+			wantErr: true,
+		},
+		{
+			name:    "option with space only in key (no =) is not flagged",
+			options: []string{"--read-only"},
+			wantErr: false,
+		},
+		{
+			name:    "first clean then one with space is rejected",
+			options: []string{"--log-level=LOG_WARNING", "--cache-size-mb=512 --tmp-path=/etc"},
+			wantErr: true,
+		},
+		{
+			// U+00A0 NBSP is Unicode whitespace; the proxy's \s+ regexp normalises it
+			// to a space before strings.Split, so it must be caught here.
+			name:    "value containing NBSP (U+00A0) is rejected",
+			options: []string{"--cache-size-mb=512\u00a0--tmp-path=/etc"},
+			wantErr: true,
+		},
+		{
+			name:    "value containing CR is rejected",
+			options: []string{"--subdirectory=foo\rbar"},
+			wantErr: true,
+		},
+		{
+			name:    "value containing FF is rejected",
+			options: []string{"--subdirectory=foo\fbar"},
+			wantErr: true,
+		},
+		{
+			name:    "value containing VT is rejected",
+			options: []string{"--subdirectory=foo\vbar"},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateMountArgValues(test.options)
+			if test.wantErr && err == nil {
+				t.Errorf("ValidateMountArgValues(%v) expected error, got nil", test.options)
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("ValidateMountArgValues(%v) unexpected error: %v", test.options, err)
+			}
+		})
+	}
+}
+
+func TestValidateContainerName(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerName string
+		wantErr       bool
+	}{
+		// valid names
+		{
+			name:          "simple valid name",
+			containerName: "pocfuse",
+			wantErr:       false,
+		},
+		{
+			name:          "minimum length (3 chars)",
+			containerName: "abc",
+			wantErr:       false,
+		},
+		{
+			name:          "maximum length (63 chars)",
+			containerName: "a123456789012345678901234567890123456789012345678901234567890ab",
+			wantErr:       false,
+		},
+		{
+			name:          "hyphens in the middle are allowed",
+			containerName: "my-storage-container",
+			wantErr:       false,
+		},
+		{
+			name:          "digits allowed",
+			containerName: "container123",
+			wantErr:       false,
+		},
+		{
+			name:          "name with spaces is rejected",
+			containerName: "pocfuse --tmp-path=/var/data/cache",
+			wantErr:       true,
+		},
+		{
+			name:          "name starting with -- is rejected",
+			containerName: "--tmp-path=/var/data",
+			wantErr:       true,
+		},
+		{
+			name:          "newline in name is rejected",
+			containerName: "poc\nfuse",
+			wantErr:       true,
+		},
+		{
+			name:          "consecutive hyphens are rejected",
+			containerName: "poc--fuse",
+			wantErr:       true,
+		},
+		{
+			name:          "leading hyphen is rejected",
+			containerName: "-pocfuse",
+			wantErr:       true,
+		},
+		{
+			name:          "trailing hyphen is rejected",
+			containerName: "pocfuse-",
+			wantErr:       true,
+		},
+		{
+			name:          "too short (2 chars) is rejected",
+			containerName: "ab",
+			wantErr:       true,
+		},
+		{
+			name:          "too long (64 chars) is rejected",
+			containerName: "a1234567890123456789012345678901234567890123456789012345678901ab",
+			wantErr:       true,
+		},
+		{
+			name:          "uppercase letters are rejected",
+			containerName: "MyContainer",
+			wantErr:       true,
+		},
+		{
+			name:          "underscore is rejected",
+			containerName: "my_container",
+			wantErr:       true,
+		},
+		{
+			name:          "empty string is allowed (workload identity paths have no container yet)",
+			containerName: "",
+			wantErr:       false,
+		},
+		// invalid names — naming rule violations
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateContainerName(test.containerName)
+			if test.wantErr && err == nil {
+				t.Errorf("ValidateContainerName(%q) expected error, got nil", test.containerName)
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("ValidateContainerName(%q) unexpected error: %v", test.containerName, err)
+			}
+		})
+	}
+}
+
 func TestAppendDefaultMountOptions(t *testing.T) {
 	tests := []struct {
 		options       []string

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -326,6 +326,14 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.InvalidArgument, "fsGroupChangePolicy(%s) is not supported, supported fsGroupChangePolicy list: %v", fsGroupChangePolicy, supportedFSGroupChangePolicyList)
 	}
 
+	// For ephemeral inline volumes the user controls volumeAttributes; an empty
+	// containerName would cause appendDefaultMountOptions to emit a bare
+	// "--container-name" flag, which shifts blobfuse2's argv and disables
+	// driver-controlled flags. Fail fast before any I/O.
+	if ephemeralVol && getValueInMap(attrib, containerNameField) == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: containerName must be specified for ephemeral volumes")
+	}
+
 	mnt, err := d.ensureMountPoint(targetPath, fs.FileMode(mountPermissions))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", targetPath, err)
@@ -343,6 +351,13 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	// replace pv/pvc name namespace metadata in subDir
 	containerName = replaceWithMap(containerName, containerNameReplaceMap)
+
+	// Validate containerName against Azure naming rules. A value
+	// containing spaces cannot match the regex and is rejected before it reaches
+	// the blobfuse2 args string.
+	if err := ValidateContainerName(containerName); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+	}
 
 	if strings.TrimSpace(storageEndpointSuffix) == "" {
 		storageEndpointSuffix = d.getStorageEndPointSuffix()
@@ -416,13 +431,36 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	// Get mountOptions that the volume will be formatted and mounted with
 	mountOptions := mountFlags
 	if ephemeralVol {
-		mountOptions = util.JoinMountOptions(mountOptions, strings.Split(ephemeralVolMountOptions, ","))
+		// Reject any user-supplied mount options that are security-sensitive and
+		// must be driver-controlled (e.g. --tmp-path). Return InvalidArgument so
+		// the caller knows their requested behaviour was not applied.
+		sanitized, err := SanitizeMountOptions(tokenizeMountOptionsString(ephemeralVolMountOptions))
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
+		mountOptions = util.JoinMountOptions(mountOptions, sanitized)
+
+		// Validate that no sanitized ephemeral mount option value contains
+		// whitespace. Only applied to inline volumes because mountOptions for
+		// PV/SC-backed volumes come from trusted cluster-admin configuration and
+		// should not be broken by this check.
+		if err := ValidateMountArgValues(sanitized); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+		}
 	}
 	if isHnsEnabled {
 		mountOptions = util.JoinMountOptions(mountOptions, []string{"--use-adls=true"})
 	}
 
 	if !checkGidPresentInMountFlags(mountFlags) && volumeMountGroup != "" {
+
+		// Validate as an unsigned integer (the POSIX GID type) before formatting it into
+		// the args string. This is a defence-in-depth check; do not rely on apiserver
+		// admission for a CSI-layer invariant.
+		if _, err := strconv.ParseUint(volumeMountGroup, 10, 32); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"invalid volumeMountGroup %q: must be an unsigned 32-bit integer (POSIX GID)", volumeMountGroup)
+		}
 		klog.V(2).Infof("append volumeMountGroup %s", volumeMountGroup)
 		mountOptions = append(mountOptions, fmt.Sprintf("-o gid=%s", volumeMountGroup))
 	}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -581,6 +581,140 @@ func TestNodeStageVolume(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "TestKnownVolumeMountGroupBypass",
+			testFunc: func(t *testing.T) {
+				maliciousGroups := []struct {
+					name  string
+					value string
+				}{
+					{name: "C1_whitespace_tab", value: "1000\t--tmp-path=/etc"},
+					{name: "C1_whitespace_space", value: "1000 --tmp-path=/etc"},
+					{name: "C2_fstab_comma_config_file", value: ",--config-file"},
+					{name: "C2_fstab_comma_prefixed_gid", value: "1000,--config-file"},
+					{name: "C2_fstab_comma_tmp_path", value: "0,--tmp-path=/etc/shadow"},
+					{name: "negative_gid", value: "-1"},
+					{name: "non_numeric", value: "root"},
+				}
+				for _, mg := range maliciousGroups {
+					t.Run(mg.name, func(t *testing.T) {
+						req := &csi.NodeStageVolumeRequest{
+							VolumeId:          "rg#acc#cont#ns",
+							StagingTargetPath: targetTest,
+							VolumeCapability: &csi.VolumeCapability{
+								AccessMode: &volumeCap,
+								AccessType: &csi.VolumeCapability_Mount{
+									Mount: &csi.VolumeCapability_MountVolume{
+										VolumeMountGroup: mg.value,
+									},
+								},
+							},
+							VolumeContext: map[string]string{
+								mountPermissionsField: "0755",
+								protocolField:         "fuse2",
+							},
+							Secrets: map[string]string{},
+						}
+						d := NewFakeDriver()
+						d.cloud.ResourceGroup = "rg"
+						d.enableBlobMockMount = true
+						fakeMounter := &fakeMounter{}
+						fakeExec := &testingexec.FakeExec{}
+						d.mounter = &mount.SafeFormatAndMount{
+							Interface: fakeMounter,
+							Exec:      fakeExec,
+						}
+
+						keyList := make([]*armstorage.AccountKey, 1)
+						fakeKey := "fakeKey"
+						fakeValue := "fakeValue"
+						keyList[0] = (&armstorage.AccountKey{
+							KeyName: &fakeKey,
+							Value:   &fakeValue,
+						})
+						mockStorageAccountsClient := NewMockSAClient(context.Background(), gomock.NewController(t), "subID", "unit-test", "unit-test", keyList)
+						d.cloud.ComputeClientFactory = mock_azclient.NewMockClientFactory(gomock.NewController(t))
+						d.cloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetAccountClient().Return(mockStorageAccountsClient).AnyTimes()
+						d.cloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).EXPECT().GetAccountClientForSub(gomock.Any()).Return(mockStorageAccountsClient, nil).AnyTimes()
+
+						_, err := d.NodeStageVolume(context.TODO(), req)
+						if err == nil {
+							t.Fatalf("expected InvalidArgument error for malicious volumeMountGroup %q, got nil", mg.value)
+						}
+						if status.Code(err) != codes.InvalidArgument {
+							t.Fatalf("expected codes.InvalidArgument for %q, got: %v", mg.value, err)
+						}
+						if !strings.Contains(err.Error(), "volumeMountGroup") {
+							t.Fatalf("expected error to mention volumeMountGroup for %q, got: %v", mg.value, err)
+						}
+					})
+				}
+			},
+		},
+		{
+			name: "service account token from secrets is propagated to attrib",
+			testFunc: func(t *testing.T) {
+				defaultAzureOAuthTokenDir = "./blob.csi.azure.com/"
+				_ = makeDir(defaultAzureOAuthTokenDir)
+				defer func() { _ = os.RemoveAll(defaultAzureOAuthTokenDir) }()
+
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						mountWithWITokenField:   "true",
+						clientIDField:           "client-id-value",
+						storageAccountNameField: "test-account",
+					},
+					Secrets: map[string]string{
+						serviceAccountTokenField: `{"api://AzureADTokenExchange":{"token":"test-token","expirationTimestamp":"2023-01-01T00:00:00Z"}}`,
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if !reflect.DeepEqual(err, nil) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, nil)
+				}
+			},
+		},
+		{
+			name: "[Error] ephemeral volume with empty containerName is rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc##ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						"csi.storage.k8s.io/ephemeral": "true",
+						// containerName intentionally absent — simulates user omitting it
+					},
+					Secrets: map[string]string{},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				expectedErr := status.Error(codes.InvalidArgument, "NodeStageVolume: containerName must be specified for ephemeral volumes")
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.testFunc)


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
Cherry-pick of #2460 onto release-1.26.

Hardens ephemeral inline volume mount option handling:
- Add `SanitizeMountOptions` allowlist to reject security-sensitive flags (e.g. `--tmp-path`, `--config-file`)
- Add `ValidateMountArgValues` to reject whitespace in mount option values
- Add `ValidateContainerName` to enforce Azure blob naming rules
- Add `tokenizeMountOptionsString` to properly parse comma/space-separated options
- Add empty containerName check for ephemeral volumes

## Which issue(s) this PR fixes
Backport security hardening to release-1.26.

## Does this PR introduce a user-facing change?
```release-note
Fix: harden ephemeral mount option validation for inline blob volumes
```