### PR TITLE
chore: use native platform for Dockerfile builder stage to avoid QEMU arm64 failures

### DIFF
--- a/pkg/blobplugin/Dockerfile
+++ b/pkg/blobplugin/Dockerfile
@@ -20,7 +20,8 @@ FROM ${BASE_IMAGE} AS base
 
 FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS builder
 
-ARG TARGETARCH=amd64
+ARG ARCH
+ARG TARGETARCH=${ARCH}
 
 RUN apt update \
     && apt install -y curl

--- a/pkg/blobplugin/Dockerfile
+++ b/pkg/blobplugin/Dockerfile
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 ARG ARCH=amd64
+ARG BUILDPLATFORM=linux/amd64
+ARG BASE_IMAGE=registry.k8s.io/build-image/debian-base:bookworm-v1.0.8
 
-FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8 AS base
+FROM ${BASE_IMAGE} AS base
 
-FROM base AS builder
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS builder
 
-ARG ARCH
+ARG TARGETARCH=amd64
 
 RUN apt update \
     && apt install -y curl
@@ -26,13 +28,13 @@ RUN apt update \
 # install aznfs
 ARG aznfsVer=2.0.12
 ARG aznfsTarPkgName=aznfs-${aznfsVer}-1.x86_64
-RUN if [ "$ARCH" = "arm64" ]; then \
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
       aznfsTarPkgName=aznfs-${aznfsVer}-1.arm64; \
     fi
 RUN curl -Ls https://github.com/Azure/AZNFS-mount/releases/download/${aznfsVer}/${aznfsTarPkgName}.tar.gz | tar xvzf - -C / --keep-directory-symlink;
 
 # install azcopy
-RUN curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.4/azcopy_linux_${ARCH}_10.32.4.tar.gz \
+RUN curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.4/azcopy_linux_${TARGETARCH}_10.32.4.tar.gz \
         | tar xvzf - --strip-components=1 -C /usr/local/bin/ --wildcards "*/azcopy"
 
 # download blobfuse deb

--- a/pkg/blobplugin/Dockerfile
+++ b/pkg/blobplugin/Dockerfile
@@ -27,11 +27,11 @@ RUN apt update \
 
 # install aznfs
 ARG aznfsVer=2.0.12
-ARG aznfsTarPkgName=aznfs-${aznfsVer}-1.x86_64
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
+RUN aznfsTarPkgName=aznfs-${aznfsVer}-1.x86_64; \
+    if [ "$TARGETARCH" = "arm64" ]; then \
       aznfsTarPkgName=aznfs-${aznfsVer}-1.arm64; \
-    fi
-RUN curl -Ls https://github.com/Azure/AZNFS-mount/releases/download/${aznfsVer}/${aznfsTarPkgName}.tar.gz | tar xvzf - -C / --keep-directory-symlink;
+    fi; \
+    curl -Ls https://github.com/Azure/AZNFS-mount/releases/download/${aznfsVer}/${aznfsTarPkgName}.tar.gz | tar xvzf - -C / --keep-directory-symlink
 
 # install azcopy
 RUN curl -Ls https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.4/azcopy_linux_${TARGETARCH}_10.32.4.tar.gz \


### PR DESCRIPTION
The builder stage only needs to download azcopy/aznfs binaries and the
Microsoft apt repo deb. Running apt install under QEMU emulation
for arm64 intermittently fails with `Exec format error` when
binfmt registration is unstable in CI Docker-in-Docker environments.

By using `--platform=\$BUILDPLATFORM`, the builder always runs natively
(amd64) and downloads the correct arch-specific binaries via
TARGETARCH, eliminating the QEMU dependency for this stage.

Give TARGETARCH a default of `amd64` so the download URLs are
always valid even when not running under BuildKit/buildx.

Same fix as kubernetes-sigs/azurefile-csi-driver#3157.