### PR TITLE
fix: allow Azure system containers ($ prefix) in ValidateContainerName for inline volume

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1240,10 +1240,17 @@ func ValidateMountArgValues(mountOptions []string) error {
 // alphanumeric characters and hyphens, names containing spaces or other special
 // characters are rejected before the value is included in the blobfuse2 args
 // string that the proxy splits on whitespace.
+//
+// Azure system containers (prefixed with "$") are allowed as they are created
+// by Azure services and are valid despite not matching standard naming rules.
 func ValidateContainerName(containerName string) error {
 	// Empty is allowed: some flows (e.g. workload identity) resolve the container
 	// name later; an empty value cannot inject any arguments.
 	if containerName == "" {
+		return nil
+	}
+	// Allow Azure system containers that use "$" prefix (e.g. $web, $root, $logs).
+	if strings.HasPrefix(containerName, "$") {
 		return nil
 	}
 	if !containerNameRegex.MatchString(containerName) {

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1250,7 +1250,11 @@ func ValidateContainerName(containerName string) error {
 		return nil
 	}
 	// Allow Azure system containers that use "$" prefix (e.g. $web, $root, $logs).
+	// Still reject whitespace to prevent argument injection via blobfuse2 argv.
 	if strings.HasPrefix(containerName, "$") {
+		if strings.ContainsAny(containerName, " \t\n\r") {
+			return fmt.Errorf("invalid containerName %q: whitespace characters are not allowed", containerName)
+		}
 		return nil
 	}
 	if !containerNameRegex.MatchString(containerName) {

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1252,7 +1252,7 @@ func ValidateContainerName(containerName string) error {
 	// Allow Azure system containers that use "$" prefix (e.g. $web, $root, $logs).
 	// Still reject whitespace to prevent argument injection via blobfuse2 argv.
 	if strings.HasPrefix(containerName, "$") {
-		if strings.ContainsAny(containerName, " \t\n\r") {
+		if strings.ContainsAny(containerName, " \t\n\r\f\v") {
 			return fmt.Errorf("invalid containerName %q: whitespace characters are not allowed", containerName)
 		}
 		return nil

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2143,6 +2143,16 @@ func TestValidateContainerName(t *testing.T) {
 			containerName: "$logs\n--inject",
 			wantErr:       true,
 		},
+		{
+			name:          "$-prefix with form-feed is rejected",
+			containerName: "$web\f--tmp-path=/var/data",
+			wantErr:       true,
+		},
+		{
+			name:          "$-prefix with vertical-tab is rejected",
+			containerName: "$root\v--inject",
+			wantErr:       true,
+		},
 		// invalid names — naming rule violations
 	}
 

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2106,6 +2106,27 @@ func TestValidateContainerName(t *testing.T) {
 			containerName: "",
 			wantErr:       false,
 		},
+		// Azure system containers
+		{
+			name:          "$web system container is allowed",
+			containerName: "$web",
+			wantErr:       false,
+		},
+		{
+			name:          "$root system container is allowed",
+			containerName: "$root",
+			wantErr:       false,
+		},
+		{
+			name:          "$logs system container is allowed",
+			containerName: "$logs",
+			wantErr:       false,
+		},
+		{
+			name:          "$blobchangefeed system container is allowed",
+			containerName: "$blobchangefeed",
+			wantErr:       false,
+		},
 		// invalid names — naming rule violations
 	}
 

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -2127,6 +2127,22 @@ func TestValidateContainerName(t *testing.T) {
 			containerName: "$blobchangefeed",
 			wantErr:       false,
 		},
+		// invalid names — $-prefix with whitespace (argv injection protection)
+		{
+			name:          "$-prefix with space is rejected",
+			containerName: "$web --tmp-path=/var/data",
+			wantErr:       true,
+		},
+		{
+			name:          "$-prefix with tab is rejected",
+			containerName: "$root\t--inject",
+			wantErr:       true,
+		},
+		{
+			name:          "$-prefix with newline is rejected",
+			containerName: "$logs\n--inject",
+			wantErr:       true,
+		},
 		// invalid names — naming rule violations
 	}
 


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

Fixes `ValidateContainerName` to allow Azure Blob Storage system containers that use a `$` prefix (e.g. `$web`, `$root`, `$logs`, `$blobchangefeed`).

Instead of maintaining a hardcoded whitelist of known system container names, the validation now allows **any** container name starting with `$`. This is safe because:
1. Users cannot create containers with `$` prefix (Azure API rejects them)
2. The `$` prefix is Azure's reserved marker for system containers
3. Azure may add new system containers in the future without requiring driver updates

### Changes
- Replace the `azureSystemContainers` map with a simple `strings.HasPrefix(containerName, "$")` check
- Add test cases for `$web`, `$root`, `$logs`, `$blobchangefeed`

### References
- [Azure container naming rules](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names)
- Supersedes #2502

Signed-off-by: Andy Zhang <andyzhangx@live.com>