### PR TITLE
fix: allow --use-adls mount option for ephemeral volumes

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -252,6 +252,7 @@ var (
 		"--read-only":                      {},
 		"--subdirectory":                   {},
 		"--sync-to-flush":                  {},
+		"--use-adls":                       {},
 		"--use-attr-cache":                 {},
 		"--virtual-directory":              {},
 		"--wait-for-mount":                 {},

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1657,6 +1657,12 @@ func TestSanitizeMountOptions(t *testing.T) {
 			wantErr:  false,
 			expected: []string{"--cancel-list-on-mount-seconds=60"},
 		},
+		{
+			name:     "--use-adls is allowed (used for ADLS Gen2/HNS accounts, see issue #2505)",
+			options:  []string{"--use-adls=true"},
+			wantErr:  false,
+			expected: []string{"--use-adls=true"},
+		},
 		// -o FUSE passthrough: a space after -o would be treated as additional flags
 		// by the proxy, so the value must be a single token.
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #2476 introduced an allowlist of blobfuse2 flags permitted in `volumeAttributes.mountOptions` for ephemeral inline volumes (`allowedEphemeralMountOptions`). The `--use-adls` flag was omitted from that allowlist, so workloads mounting ADLS Gen2 / HNS accounts via inline volumes started failing with:

```
mount option "--use-adls" is not allowed for ephemeral volumes
```

`--use-adls` only toggles ADLS Gen2 (hierarchical namespace) semantics; it does not redirect host paths (`--tmp-path`, `--block-cache-path`), load arbitrary config (`--config-file`), or override driver-controlled values (`--container-name`). It therefore meets the same safety criteria as the other allowlisted flags. Notably, the driver itself appends `--use-adls=true` when HNS is detected, confirming it is a trusted flag.

This adds `--use-adls` to `allowedEphemeralMountOptions` and covers it with a unit test.

**Which issue(s) this PR fixes**:

Fixes #2505

**Special notes for your reviewer**:

Regression introduced in #2476.

**Release note**:
```release-note
Fix `--use-adls` mount option being rejected on ephemeral inline volumes.
```