### PR TITLE
chore: lower blobfuse proxy health metric verbosity

### DIFF
--- a/pkg/blob/proxy_monitor.go
+++ b/pkg/blob/proxy_monitor.go
@@ -70,7 +70,7 @@ func (m *BlobfuseProxyMonitor) Start(ctx context.Context) {
 
 // checkHealth checks health and records metrics.
 func (m *BlobfuseProxyMonitor) checkHealth() {
-	mc := csiMetrics.NewCSIMetricContext("blobfuse_proxy_health")
+	mc := csiMetrics.NewCSIMetricContext("blobfuse_proxy_health").WithLogLevel(6)
 	isOperationSucceeded := m.isProxyReachable()
 	mc.Observe(isOperationSucceeded)
 }


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Decrease verbosity of blobfuse proxy health monitor metric logging.  Default metric loglevel is too noisy.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [x] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
