### PR TITLE
cleanup: add periodic progress logging for SetVolumeOwnership during NodeStageVolume

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -447,6 +447,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 					case <-done:
 						return
 					case <-ticker.C:
+						select {
+						case <-done:
+							return
+						default:
+						}
 						klog.Infof("SetVolumeOwnership for volume(%s) on %s is still running (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
 					}
 				}
@@ -456,7 +461,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			if err != nil {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("SetVolumeOwnership with volume(%s) on %s failed with %v", volumeID, targetPath, err))
 			}
-			klog.V(2).Infof("SetVolumeOwnership for volume(%s) on %s completed (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
+			klog.Infof("SetVolumeOwnership for volume(%s) on %s completed successfully (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
 		}
 
 		isOperationSucceeded = true

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -437,9 +437,26 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 		if volumeMountGroup != "" && fsGroupChangePolicy != FSGroupChangeNone {
 			klog.V(2).Infof("set gid of volume(%s) as %s using fsGroupChangePolicy(%s)", volumeID, volumeMountGroup, fsGroupChangePolicy)
-			if err := volumehelper.SetVolumeOwnership(targetPath, volumeMountGroup, fsGroupChangePolicy); err != nil {
+			start := time.Now()
+			done := make(chan struct{})
+			go func() {
+				ticker := time.NewTicker(30 * time.Second)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-done:
+						return
+					case <-ticker.C:
+						klog.Infof("SetVolumeOwnership for volume(%s) on %s is still running (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
+					}
+				}
+			}()
+			err := volumehelper.SetVolumeOwnership(targetPath, volumeMountGroup, fsGroupChangePolicy)
+			close(done)
+			if err != nil {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("SetVolumeOwnership with volume(%s) on %s failed with %v", volumeID, targetPath, err))
 			}
+			klog.V(2).Infof("SetVolumeOwnership for volume(%s) on %s completed (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
 		}
 
 		isOperationSucceeded = true

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -452,7 +452,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 							return
 						default:
 						}
-						klog.Infof("SetVolumeOwnership for volume(%s) on %s is still running (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
+						klog.V(2).Infof("SetVolumeOwnership for volume(%s) on %s is still running (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
 					}
 				}
 			}()
@@ -461,7 +461,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			if err != nil {
 				return nil, status.Error(codes.Internal, fmt.Sprintf("SetVolumeOwnership with volume(%s) on %s failed with %v", volumeID, targetPath, err))
 			}
-			klog.Infof("SetVolumeOwnership for volume(%s) on %s completed successfully (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
+			klog.V(2).Infof("SetVolumeOwnership for volume(%s) on %s completed successfully (elapsed: %v)", volumeID, targetPath, time.Since(start).Round(time.Second))
 		}
 
 		isOperationSucceeded = true

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -753,12 +753,11 @@ func TestNodeStageVolume(t *testing.T) {
 				}
 
 				_, err := d.NodeStageVolume(context.TODO(), req)
-				// SetVolumeOwnership may fail in test env (target path doesn't exist as a real mount)
-				// but we verify the code path is reached without panics
-				if err != nil {
-					// Expected: either success or SetVolumeOwnership error (not a panic or nil pointer)
-					assert.Contains(t, err.Error(), "SetVolumeOwnership")
-				}
+				// In the test environment the staging target path is not a real mount,
+				// so SetVolumeOwnership must fail. Asserting a non-nil error that
+				// mentions SetVolumeOwnership proves the code path was reached.
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "SetVolumeOwnership")
 			},
 		},
 		{

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -722,6 +722,46 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "protocol = nfs with volumeMountGroup triggers SetVolumeOwnership",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessMode: &volumeCap,
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								VolumeMountGroup: "1000",
+							},
+						},
+					},
+					VolumeContext: map[string]string{
+						mountPermissionsField:    "0755",
+						protocolField:            "nfs",
+						fsGroupChangePolicyField: "OnRootMismatch",
+					},
+					Secrets: map[string]string{},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				// SetVolumeOwnership may fail in test env (target path doesn't exist as a real mount)
+				// but we verify the code path is reached without panics
+				if err != nil {
+					// Expected: either success or SetVolumeOwnership error (not a panic or nil pointer)
+					assert.Contains(t, err.Error(), "SetVolumeOwnership")
+				}
+			},
+		},
+		{
 			name: "BlobMockMount Enabled",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -731,7 +731,7 @@ func TestNodeStageVolume(t *testing.T) {
 						AccessMode: &volumeCap,
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
-								VolumeMountGroup: "1000",
+								VolumeMountGroup: "invalid-gid",
 							},
 						},
 					},
@@ -753,12 +753,10 @@ func TestNodeStageVolume(t *testing.T) {
 				}
 
 				_, err := d.NodeStageVolume(context.TODO(), req)
-				// SetVolumeOwnership may succeed or fail depending on the test
-				// environment. When it fails, verify the error mentions
-				// SetVolumeOwnership to confirm the code path was reached.
-				if err != nil {
-					assert.Contains(t, err.Error(), "SetVolumeOwnership")
-				}
+				// "invalid-gid" cannot be parsed as an integer, so SetVolumeOwnership
+				// deterministically fails with a conversion error.
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "SetVolumeOwnership")
 			},
 		},
 		{

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -753,11 +753,12 @@ func TestNodeStageVolume(t *testing.T) {
 				}
 
 				_, err := d.NodeStageVolume(context.TODO(), req)
-				// In the test environment the staging target path is not a real mount,
-				// so SetVolumeOwnership must fail. Asserting a non-nil error that
-				// mentions SetVolumeOwnership proves the code path was reached.
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "SetVolumeOwnership")
+				// SetVolumeOwnership may succeed or fail depending on the test
+				// environment. When it fails, verify the error mentions
+				// SetVolumeOwnership to confirm the code path was reached.
+				if err != nil {
+					assert.Contains(t, err.Error(), "SetVolumeOwnership")
+				}
 			},
 		},
 		{

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -562,7 +562,7 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		fsGroup := int64(1000)
 		pods := []testsuites.PodDetails{
 			{
-				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Cmd:     "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
 				FSGroup: &fsGroup,
 				Volumes: []testsuites.VolumeDetails{
 					{

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -555,13 +555,15 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
-	ginkgo.It("should create a NFSv3 volume on demand with mount options [nfs]", func(ctx ginkgo.SpecContext) {
+	ginkgo.It("should create a NFSv3 volume on demand with mount options and fsGroup [nfs]", func(ctx ginkgo.SpecContext) {
 		if isAzureStackCloud {
 			ginkgo.Skip("test case is not available for Azure Stack")
 		}
+		fsGroup := int64(1000)
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				FSGroup: &fsGroup,
 				Volumes: []testsuites.VolumeDetails{
 					{
 						ClaimSize: "10Gi",

--- a/test/e2e/testsuites/specs.go
+++ b/test/e2e/testsuites/specs.go
@@ -115,9 +115,10 @@ func (pod *PodDetails) SetupWithDynamicVolumes(ctx context.Context, client clien
 		}
 	}
 	if pod.FSGroup != nil {
-		tpod.pod.Spec.SecurityContext = &v1.PodSecurityContext{
-			FSGroup: pod.FSGroup,
+		if tpod.pod.Spec.SecurityContext == nil {
+			tpod.pod.Spec.SecurityContext = &v1.PodSecurityContext{}
 		}
+		tpod.pod.Spec.SecurityContext.FSGroup = pod.FSGroup
 	}
 	return tpod, cleanupFuncs
 }

--- a/test/e2e/testsuites/specs.go
+++ b/test/e2e/testsuites/specs.go
@@ -33,6 +33,7 @@ import (
 type PodDetails struct {
 	Cmd     string
 	Volumes []VolumeDetails
+	FSGroup *int64
 }
 
 type VolumeDetails struct {
@@ -111,6 +112,11 @@ func (pod *PodDetails) SetupWithDynamicVolumes(ctx context.Context, client clien
 			tpod.SetupRawBlockVolume(tpvc.persistentVolumeClaim, fmt.Sprintf("%s%d", v.VolumeDevice.NameGenerate, n+1), v.VolumeDevice.DevicePath)
 		} else {
 			tpod.SetupVolume(tpvc.persistentVolumeClaim, fmt.Sprintf("%s%d", v.VolumeMount.NameGenerate, n+1), fmt.Sprintf("%s%d", v.VolumeMount.MountPathGenerate, n+1), v.VolumeMount.ReadOnly)
+		}
+	}
+	if pod.FSGroup != nil {
+		tpod.pod.Spec.SecurityContext = &v1.PodSecurityContext{
+			FSGroup: pod.FSGroup,
 		}
 	}
 	return tpod, cleanupFuncs


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it
When `SetVolumeOwnership` runs on large NFS volumes, the recursive chown/chmod can take hours with no log output, making it appear as if the node driver is hung. This change adds a background goroutine that logs progress every 30 seconds while `SetVolumeOwnership` is running, including the volume ID, target path, and elapsed time. A completion log line is also added.

**Before:** No output during long-running `SetVolumeOwnership` — operators cannot tell if progress is being made.

**After:** Periodic log messages every 30s:
```
I0619 04:00:30.000000   SetVolumeOwnership for volume(pvc-xxx) on /target/path is still running (elapsed: 30s)
I0619 04:01:00.000000   SetVolumeOwnership for volume(pvc-xxx) on /target/path is still running (elapsed: 1m0s)
I0619 04:05:00.000000   SetVolumeOwnership for volume(pvc-xxx) on /target/path completed (elapsed: 5m0s)
```

## Which issue(s) this PR fixes
Fixes #2515

## Does this PR introduce a user-facing change?
```release-note
Add periodic progress logging (every 30s) for SetVolumeOwnership during NodeStageVolume for NFS volumes, providing visibility into long-running recursive chown/chmod operations.
```