### PR TITLE
[release-1.27] cherry-pick: allow blobfuse2 attr-cache-max-size-mb and kernel-list-cache-timeout on ephemeral volumes

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -161,6 +161,11 @@ kubectl create secret generic azure-secret --from-literal azurestoragespnclients
  - blobfuse cache(`--tmp-path` [mount option](https://github.com/Azure/azure-storage-fuse/tree/blobfuse-1.4.5#mount-options))
    - By default, the blobfuse cache is located in the `/mnt` directory. If the VM SKU provides a temporary disk, the `/mnt` directory is mounted on the temporary disk. However, if the VM SKU does not provide a temporary disk, the `/mnt` directory is mounted on the OS disk. 
    - with blobfuse-proxy deployment (default on AKS), user could set `--tmp-path=` mount option to specify a different cache directory
+ - blobfuse2 attribute cache and kernel list cache tuning (requires blobfuse2 v2.5.4+, shipped by default)
+   - `--attr-cache-max-size-mb=<sizeInMB>`: maximum memory in MB that the attribute cache can use (`0` = auto-tune to 1% of total RAM, clamped to `[64 MB, 1 GB]`). Increase for workloads with large directory trees or many distinct file paths.
+   - `--kernel-list-cache-timeout=<seconds>`: enable kernel caching of directory listings and set the TTL in seconds (fuse3 only). `0` = disabled. Reduces backend `readdir` traffic for read-heavy workloads.
+   - Both are passed via `mountOptions` on the PV/StorageClass, and are also permitted on ephemeral inline volumes.
+ - If there are CVEs in the `livenessprobe` and `csi-node-driver-registrar` sidecar images, you can run `kubectl edit ds -n kube-system csi-blob-node` to change the `imagePullPolicy` to `Always` for both sidecar containers. This will cause the CSI driver to restart and pull the latest patched images, thereby resolving the CVEs in these sidecar components.
  - [Mount Azure blob storage with managed identity](../deploy/example/blobfuse-mi)
  - [Blobfuse Performance and caching](https://github.com/Azure/azure-storage-fuse?tab=readme-ov-file#frequently-asked-questions)
  - [Blobfuse CLI Flag Options v1 & v2](https://github.com/Azure/azure-storage-fuse/blob/main/MIGRATION.md#blobfuse-cli-flag-options)

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -208,6 +208,7 @@ var (
 	// they are handled separately in SanitizeMountOptions.
 	allowedEphemeralMountOptions = map[string]struct{}{
 		"--allow-other":                    {},
+		"--attr-cache-max-size-mb":         {},
 		"--attr-cache-timeout":             {},
 		"--attr-timeout":                   {},
 		"--background-download":            {},
@@ -247,6 +248,7 @@ var (
 		"--ignore-open-flags":              {},
 		"--ignore-sync":                    {},
 		"--invalidate-on-sync":             {},
+		"--kernel-list-cache-timeout":      {},
 		"--lazy-write":                     {},
 		"--list-cache-timeout":             {},
 		"--log-goroutine-id":               {},

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1561,6 +1561,12 @@ func TestSanitizeMountOptions(t *testing.T) {
 			expected: []string{"--log-level=LOG_WARNING", "--cache-size-mb=1000"},
 		},
 		{
+			name:     "newly allowed attr-cache-max-size-mb and kernel-list-cache-timeout pass through",
+			options:  []string{"--attr-cache-max-size-mb=256", "--kernel-list-cache-timeout=120"},
+			wantErr:  false,
+			expected: []string{"--attr-cache-max-size-mb=256", "--kernel-list-cache-timeout=120"},
+		},
+		{
 			name:     "-o FUSE passthrough token is always allowed",
 			options:  []string{"-o allow_other", "--log-level=LOG_WARNING"},
 			wantErr:  false,


### PR DESCRIPTION
Cherry-pick of #2558 to release-1.27.

Original PR: https://github.com/kubernetes-sigs/blob-csi-driver/pull/2558

---
**Changes:**
- Add `--attr-cache-max-size-mb` and `--kernel-list-cache-timeout` to allowedEphemeralMountOptions
- Extend TestSanitizeMountOptions with a case covering both flags
- Document them in docs/driver-parameters.md