### PR TITLE
fix: skip ReadDir health probe on NodePublishVolume republish

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -777,6 +777,18 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 //   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
 //   - (false, nil) if the target was freshly created or successfully unmounted
 //   - (false, err) on other failures
+// ensureMountPoint verifies that target is a valid mount point.
+//
+// When shouldUnmount is true (NodeStageVolume path), a data-plane ReadDir(1)
+// probe is issued to detect stale blobfuse mounts; if the probe fails the
+// mount is unmounted so it can be remounted by the caller.
+//
+// When shouldUnmount is false (NodePublishVolume republish path), the ReadDir
+// probe is skipped: the mount table entry is treated as authoritative for the
+// bind mount, so the function returns (true, nil) without contacting the
+// blobfuse data plane. This avoids issuing one ListBlobs REST call per
+// pod-volume on every kubelet republish (~1min when
+// CSIDriver.spec.requiresRepublish=true), which is expensive at scale.
 func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {
@@ -812,7 +824,7 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 		// health probe: the mount table entry is authoritative for the bind mount, and
 		// kubelet republishes every ~1min due to CSIDriver.spec.requiresRepublish=true.
 		// A per-republish ReadDir would translate into a ListBlobs call per pod-volume
-		// even when the workload is idle, which is expensive at scale (see #issue).
+		// even when the workload is idle, which is expensive at scale.
 		if !shouldUnmount {
 			klog.V(2).Infof("already mounted to target %s", target)
 			return !notMnt, nil

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -768,16 +768,6 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 }
 
 // ensureMountPoint: create mount point if not exists.
-// When shouldUnmount is true (e.g. NodeStageVolume), a stale mount is unmounted so it can be
-// re-established. When shouldUnmount is false (e.g. NodePublishVolume), a stale mount is left
-// in place and the error is returned so kubelet can retry; this avoids a race where unmounting
-// during periodic republish causes data loss if the application container is writing.
-// Returns:
-//   - (true, nil) if the target is already a healthy mount point
-//   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
-//   - (false, nil) if the target was freshly created or successfully unmounted
-//   - (false, err) on other failures
-// ensureMountPoint verifies that target is a valid mount point.
 //
 // When shouldUnmount is true (NodeStageVolume path), a data-plane ReadDir(1)
 // probe is issued to detect stale blobfuse mounts; if the probe fails the
@@ -789,6 +779,12 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 // blobfuse data plane. This avoids issuing one ListBlobs REST call per
 // pod-volume on every kubelet republish (~1min when
 // CSIDriver.spec.requiresRepublish=true), which is expensive at scale.
+//
+// Returns:
+//   - (true, nil) if the target is already a healthy mount point
+//   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
+//   - (false, nil) if the target was freshly created or successfully unmounted
+//   - (false, err) on other failures
 func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -808,6 +808,16 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 	}
 
 	if !notMnt {
+		// For NodePublishVolume (shouldUnmount=false), skip the data-plane ReadDir(1)
+		// health probe: the mount table entry is authoritative for the bind mount, and
+		// kubelet republishes every ~1min due to CSIDriver.spec.requiresRepublish=true.
+		// A per-republish ReadDir would translate into a ListBlobs call per pod-volume
+		// even when the workload is idle, which is expensive at scale (see #issue).
+		if !shouldUnmount {
+			klog.V(2).Infof("already mounted to target %s", target)
+			return !notMnt, nil
+		}
+
 		// testing original mount point, make sure the mount link is valid
 		// Use ReadDir(1) instead of full os.ReadDir to avoid expensive directory listing
 		// on blobfuse mounts with many files. ReadDir(1) makes only one BlockBlob.List()

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -136,11 +136,13 @@ func TestEnsureMountPoint(t *testing.T) {
 		}
 	}
 
-	// Test shouldUnmount=false: error is returned but unmount is not called.
+	// Test shouldUnmount=false: mount table entry is authoritative, health probe
+	// is skipped to avoid a data-plane ListBlobs on every NodePublishVolume
+	// republish. Expect no error and no Unmount calls.
 	unmountCountBefore := fakeMounter.unmountCount
 	_, err := d.ensureMountPoint(falseTarget, 0777, false)
-	if err == nil {
-		t.Errorf("[shouldUnmount=false] expected error for stale mount target, got nil")
+	if err != nil {
+		t.Errorf("[shouldUnmount=false] expected no error when mount table entry is present, got %v", err)
 	}
 	if fakeMounter.unmountCount != unmountCountBefore {
 		t.Errorf("[shouldUnmount=false] expected no Unmount calls, but got %d", fakeMounter.unmountCount-unmountCountBefore)


### PR DESCRIPTION
**What this PR does / why we need it:**

With `CSIDriver.spec.requiresRepublish: true` (default), kubelet re-invokes `NodePublishVolume` roughly every 60–90s per pod-volume. For an already-published target, `ensureMountPoint()` performs `os.Open + ReadDir(1)` on the bind-mounted path as a mount liveness probe. On blobfuse, that `ReadDir(1)` becomes a **ListBlobs** call, and if the container root has virtual directories without marker blobs, it triggers **GetBlobProperties** amplification (in one repro: ~197 GetBlobProperties per ListBlobs).

At scale, this produces significant idle-mode traffic:
- 750 pods × ~1 republish / 75s ≈ **~570 ListBlobs/min** just for liveness probing
- With no directory markers, that's tens of thousands of GetBlobProperties/min

**Fix:** For `NodePublishVolume` (`shouldUnmount=false`), rely on the mount table entry (already checked earlier in `ensureMountPoint`) as authoritative proof of the bind mount. The underlying FUSE mount health is validated on `NodeStageVolume` (`shouldUnmount=true`) where the `ReadDir(1)` probe is retained.

This mirrors the approach used by the GCS FUSE CSI driver, which also runs with `requiresRepublish: true` but does not read the mounted bucket on every republish.

**Reproduction:**
A single pod running just `sleep 86400` with one blobfuse volume produced 7 periodic `ListBlobs` calls over ~10 minutes (intervals 90/75/73/83/71/83s).

**Release note:**
```release-note
Skip the ReadDir(1) mount health probe on NodePublishVolume republish to avoid periodic ListBlobs/GetBlobProperties transactions on idle blobfuse mounts.
```