### PR TITLE
fix: use syscall.Statfs instead of ReadDir for mount health probe

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -205,8 +205,8 @@ def get_regexs():
     # dates can be 2014, 2015, 2016, ..., CURRENT_YEAR, company holder names can be anything
     years = range(2014, date.today().year + 1)
     regexs["date"] = re.compile( '(%s)' % "|".join(map(lambda l: str(l), years)) )
-    # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    # strip //go:build and // +build \n\n build constraints
+    regexs["go_build_constraints"] = re.compile(r"^(//go:build.*\n|// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     # Search for generated files

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -18,10 +18,8 @@ package blob
 
 import (
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -769,16 +767,17 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 
 // ensureMountPoint: create mount point if not exists.
 //
-// When shouldUnmount is true (NodeStageVolume path), a data-plane ReadDir(1)
-// probe is issued to detect stale blobfuse mounts; if the probe fails the
-// mount is unmounted so it can be remounted by the caller.
+// Uses a lightweight kernel-level probe (probeMount) to detect stale mounts.
+// On Linux this calls syscall.Statfs, which is served entirely by the kernel
+// FUSE layer without issuing any data-plane request to Azure Blob Storage.
+// On Windows it uses os.Lstat. Both detect the failure modes that matter:
+// ENOTCONN (blobfuse died), ESTALE, EIO.
 //
-// When shouldUnmount is false (NodePublishVolume republish path), the ReadDir
-// probe is skipped: the mount table entry is treated as authoritative for the
-// bind mount, so the function returns (true, nil) without contacting the
-// blobfuse data plane. This avoids issuing one ListBlobs REST call per
-// pod-volume on every kubelet republish (~1min when
-// CSIDriver.spec.requiresRepublish=true), which is expensive at scale.
+// When shouldUnmount is true (NodeStageVolume path), a failed probe triggers
+// an unmount so the mount can be recreated by the caller.
+//
+// When shouldUnmount is false (NodePublishVolume republish path), a failed
+// probe returns the error without unmounting to avoid a data-loss race.
 //
 // Returns:
 //   - (true, nil) if the target is already a healthy mount point
@@ -816,36 +815,23 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 	}
 
 	if !notMnt {
-		// For NodePublishVolume (shouldUnmount=false), skip the data-plane ReadDir(1)
-		// health probe: the mount table entry is authoritative for the bind mount, and
-		// kubelet republishes every ~1min due to CSIDriver.spec.requiresRepublish=true.
-		// A per-republish ReadDir would translate into a ListBlobs call per pod-volume
-		// even when the workload is idle, which is expensive at scale.
-		if !shouldUnmount {
-			klog.V(2).Infof("already mounted to target %s", target)
-			return !notMnt, nil
-		}
-
-		// testing original mount point, make sure the mount link is valid
-		// Use ReadDir(1) instead of full os.ReadDir to avoid expensive directory listing
-		// on blobfuse mounts with many files. ReadDir(1) makes only one BlockBlob.List()
-		// call (returning up to 5000 entries) regardless of directory size.
-		f, err := os.Open(target)
-		if err == nil {
-			defer f.Close()
-			_, err = f.ReadDir(1)
-			// EOF means empty directory, which is valid
-			if err == io.EOF {
-				err = nil
-			}
-		}
+		// testing original mount point, make sure the mount link is valid.
+		// Use a cheap kernel-level probe (probeMount) instead of ReadDir(1):
+		// on Linux this calls syscall.Statfs which is served entirely by the
+		// kernel FUSE layer, so it does not issue any data-plane request to
+		// Azure Blob Storage. ReadDir would translate into a BlockBlob.List()
+		// (ListBlobs) REST call which is expensive on large containers and
+		// adds unnecessary load on every mount health probe. The Statfs-based
+		// check still detects the failure modes we care about (ENOTCONN when
+		// the blobfuse process died, ESTALE, EIO on a broken mount).
+		err := probeMount(target)
 		if err == nil {
 			klog.V(2).Infof("already mounted to target %s", target)
 			return !notMnt, nil
 		}
 		if shouldUnmount {
 			// mount link is invalid, now unmount and remount later
-			klog.Warningf("ReadDir %s failed with %v, unmounting stale mount to fix it", target, err)
+			klog.Warningf("probeMount %s failed with %v, unmounting stale mount to fix it", target, err)
 			if err := d.mounter.Unmount(target); err != nil {
 				klog.Errorf("Unmount directory %s failed with %v", target, err)
 				return !notMnt, err
@@ -855,7 +841,7 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 		}
 		// shouldUnmount is false: skip unmount to avoid data-loss race, but return
 		// the error so kubelet can surface the failure and retry.
-		klog.Warningf("ReadDir %s failed with %v, skipping unmount (shouldUnmount=false)", target, err)
+		klog.Warningf("probeMount %s failed with %v, skipping unmount (shouldUnmount=false)", target, err)
 		return !notMnt, err
 	}
 	if err := volumehelper.MakeDir(target, perm); err != nil {

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -815,6 +816,16 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 	}
 
 	if !notMnt {
+		// For NodePublishVolume (shouldUnmount=false), skip the data-plane
+		// health probe: the mount table entry is authoritative for the bind
+		// mount, and kubelet republishes every ~1min due to
+		// CSIDriver.spec.requiresRepublish=true. A per-republish probe would
+		// be wasteful even though probeMount is cheap.
+		if !shouldUnmount {
+			klog.V(2).Infof("already mounted to target %s", target)
+			return !notMnt, nil
+		}
+
 		// testing original mount point, make sure the mount link is valid.
 		// Use a cheap kernel-level probe (probeMount) instead of ReadDir(1):
 		// on Linux this calls syscall.Statfs which is served entirely by the

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -100,7 +100,7 @@ func TestEnsureMountPoint(t *testing.T) {
 		{
 			desc:        "[Error] Error opening file",
 			target:      falseTarget,
-			expectedErr: &os.PathError{Op: "open", Path: "./false_is_likely_target", Err: syscall.ENOENT},
+			expectedErr: syscall.ENOENT,
 		},
 		{
 			desc:        "[Error] Not a directory",

--- a/pkg/blob/nodeserver_unix.go
+++ b/pkg/blob/nodeserver_unix.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -13,8 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build !windows
 
 package blob
 

--- a/pkg/blob/nodeserver_unix.go
+++ b/pkg/blob/nodeserver_unix.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -16,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+//go:build !windows
+// +build !windows
 
 package blob
 

--- a/pkg/blob/nodeserver_unix.go
+++ b/pkg/blob/nodeserver_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import "syscall"
+
+// probeMount performs a lightweight mount-liveness check on target.
+//
+// It uses syscall.Statfs, which is served by the kernel FUSE layer without
+// issuing any data-plane request to Azure Blob Storage, while still surfacing
+// the failure modes we care about (ENOTCONN when the blobfuse process died,
+// ESTALE, EIO on a broken mount).
+func probeMount(target string) error {
+	var stat syscall.Statfs_t
+	return syscall.Statfs(target, &stat)
+}

--- a/pkg/blob/nodeserver_unix.go
+++ b/pkg/blob/nodeserver_unix.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 //go:build !windows
-// +build !windows
 
 package blob
 

--- a/pkg/blob/nodeserver_windows.go
+++ b/pkg/blob/nodeserver_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -13,8 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build windows
 
 package blob
 

--- a/pkg/blob/nodeserver_windows.go
+++ b/pkg/blob/nodeserver_windows.go
@@ -1,6 +1,3 @@
-//go:build windows
-// +build windows
-
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -16,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+//go:build windows
+// +build windows
 
 package blob
 

--- a/pkg/blob/nodeserver_windows.go
+++ b/pkg/blob/nodeserver_windows.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 //go:build windows
-// +build windows
 
 package blob
 

--- a/pkg/blob/nodeserver_windows.go
+++ b/pkg/blob/nodeserver_windows.go
@@ -19,15 +19,26 @@ limitations under the License.
 
 package blob
 
-import "os"
+import (
+	"errors"
+	"os"
+	"syscall"
+)
 
 // probeMount performs a lightweight mount-liveness check on target.
 //
 // blobfuse itself is Linux-only; on Windows the driver runs against SMB via
 // csi-proxy and there is no FUSE mount to probe. Fall back to os.Lstat, which
 // is a cheap kernel-level check that still detects a missing or broken
-// target path.
+// target path. We unwrap the PathError to return the underlying syscall
+// errno directly, keeping behavior consistent with the Linux Statfs path.
 func probeMount(target string) error {
 	_, err := os.Lstat(target)
+	if err != nil {
+		var errno syscall.Errno
+		if errors.As(err, &errno) {
+			return errno
+		}
+	}
 	return err
 }

--- a/pkg/blob/nodeserver_windows.go
+++ b/pkg/blob/nodeserver_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import "os"
+
+// probeMount performs a lightweight mount-liveness check on target.
+//
+// blobfuse itself is Linux-only; on Windows the driver runs against SMB via
+// csi-proxy and there is no FUSE mount to probe. Fall back to os.Lstat, which
+// is a cheap kernel-level check that still detects a missing or broken
+// target path.
+func probeMount(target string) error {
+	_, err := os.Lstat(target)
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it**

`ensureMountPoint` currently uses `ReadDir(1)` on the mount root to check whether the existing mount is still healthy. On a blobfuse mount `ReadDir` translates into a `BlockBlob.List()` (ListBlobs) REST call against Azure Blob Storage. It works for correctness, but it is unnecessarily heavy for a mount-liveness check:

- It hits the Azure Storage data plane on every `NodeStageVolume` (and used to run on every `NodePublishVolume` republish before #2572).
- On containers with many blobs, each call pulls up to 5000 entries even though we only need to know "is the FUSE mount alive".

This PR replaces the `ReadDir(1)` probe with `syscall.Statfs` on the mount root:

- `Statfs` is served entirely by the kernel FUSE layer; no data-plane request is issued to Azure Blob Storage.
- It still detects the failure modes we actually care about for a mount-liveness check: `ENOTCONN` (blobfuse process died), `ESTALE`, `EIO` on a broken mount.
- Prior art: the GCS FUSE CSI driver uses the same kernel-only pattern for mount health probes.

**Which issue(s) this PR fixes**
Follow-up to #2572.

**Special notes for your reviewer**
- `NodePublishVolume` republish already skips the probe entirely after #2572; this PR makes the remaining `NodeStageVolume` probe cheap.
- Existing `TestEnsureMountPoint` updated: the non-existent-target case now surfaces `syscall.ENOENT` directly from `Statfs` instead of `&os.PathError{Op:"open", ...}`.

**Release note**
```release-note
Replace the ReadDir-based mount health probe with syscall.Statfs to avoid unnecessary Azure Blob ListBlobs calls on NodeStageVolume.
```