### PR TITLE
fix: prevent ARM throttling on kubelet requiresRepublish for clientID-based mounts

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -936,10 +936,22 @@ func getServiceAccountTokens(secrets, volumeContext map[string]string) string {
 // the call entirely avoids that overhead.
 // The mountWithWIToken path is excluded so credential rotation continues on every
 // republish.
+//
+// A lightweight os.Lstat is used to detect stale/broken mounts (ENOTCONN, ESTALE)
+// so we don't mask failures by returning success on a dead mount.
 func (d *Driver) canSkipRepublishNodeStage(volumeContext map[string]string, target string) bool {
 	if strings.EqualFold(getValueInMap(volumeContext, mountWithWITokenField), trueValue) {
 		return false
 	}
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
-	return err == nil && !notMnt
+	if err != nil || notMnt {
+		return false
+	}
+	// Verify the mount is healthy: os.Lstat is served by the kernel VFS
+	// and returns ENOTCONN/ESTALE when the FUSE process died or the mount
+	// is broken, without issuing any data-plane request.
+	if _, err := os.Lstat(target); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -930,12 +930,14 @@ func getServiceAccountTokens(secrets, volumeContext map[string]string) string {
 // requiresRepublish retry (target already mounted) whose auth mode has no time-bound
 // credential to refresh. When true, callers should return success without re-invoking
 // NodeStageVolume, avoiding wasteful ARM API calls (GetAccountInfo/ListKeys for
-// clientID-only mounts) whose result would be discarded because NodeStageVolume's
-// ensureMountPoint short-circuits on an existing mount.
+// clientID-only mounts). Although NodeStageVolume would eventually return early
+// when it sees the mount is already present (mnt==true after ensureMountPoint),
+// it still performs GetAuthEnv and other setup work before that check — skipping
+// the call entirely avoids that overhead.
 // The mountWithWIToken path is excluded so credential rotation continues on every
 // republish.
-func (d *Driver) canSkipRepublishNodeStage(context map[string]string, target string) bool {
-	if strings.EqualFold(getValueInMap(context, mountWithWITokenField), trueValue) {
+func (d *Driver) canSkipRepublishNodeStage(volumeContext map[string]string, target string) bool {
+	if strings.EqualFold(getValueInMap(volumeContext, mountWithWITokenField), trueValue) {
 		return false
 	}
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -85,6 +85,10 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	if context != nil {
 		// token request
 		if serviceAccountTokens != "" && useWorkloadIdentity(context) {
+			if d.canSkipRepublishNodeStage(context, target) {
+				klog.V(2).Infof("NodePublishVolume: volume(%s) already mounted on %s with clientID auth, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
+				return &csi.NodePublishVolumeResponse{}, nil
+			}
 			klog.V(2).Infof("NodePublishVolume: volume(%s) mount on %s with service account token, clientID: %s", volumeID, target, getValueInMap(context, clientIDField))
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 				StagingTargetPath: target,
@@ -103,6 +107,10 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 				// only get storage account from secret
 				setKeyValueInMap(context, getAccountKeyFromSecretField, trueValue)
 				setKeyValueInMap(context, storageAccountField, "")
+			}
+			if d.canSkipRepublishNodeStage(context, target) {
+				klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) already mounted on %s, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
+				return &csi.NodePublishVolumeResponse{}, nil
 			}
 			klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
@@ -916,4 +924,20 @@ func getServiceAccountTokens(secrets, volumeContext map[string]string) string {
 	}
 	// Fallback to volume context for backward compatibility
 	return getValueInMap(volumeContext, serviceAccountTokenField)
+}
+
+// canSkipRepublishNodeStage reports whether a NodePublishVolume call is a kubelet
+// requiresRepublish retry (target already mounted) whose auth mode has no time-bound
+// credential to refresh. When true, callers should return success without re-invoking
+// NodeStageVolume, avoiding wasteful ARM API calls (GetAccountInfo/ListKeys for
+// clientID-only mounts) whose result would be discarded because NodeStageVolume's
+// ensureMountPoint short-circuits on an existing mount.
+// The mountWithWIToken path is excluded so credential rotation continues on every
+// republish.
+func (d *Driver) canSkipRepublishNodeStage(context map[string]string, target string) bool {
+	if strings.EqualFold(getValueInMap(context, mountWithWITokenField), trueValue) {
+		return false
+	}
+	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
+	return err == nil && !notMnt
 }

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -384,6 +384,52 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "[Success] Republish for clientID-only mount already mounted skips NodeStageVolume",
+			setup: func(_ *Driver) {
+				_ = makeDir("./false_is_likely_republish_clientid")
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "csi-clientid-republish-already-mounted",
+				TargetPath:        "./false_is_likely_republish_clientid",
+				StagingTargetPath: sourceTest,
+				Readonly:          true,
+				VolumeContext: map[string]string{
+					storageAccountField:      "teststorageaccount",
+					containerNameField:       "testcontainer",
+					clientIDField:            "test-client-id-1234",
+					serviceAccountTokenField: `{"api://AzureADTokenExchange":{"token":"test-token","expirationTimestamp":"2023-01-01T00:00:00Z"}}`,
+				},
+			},
+			expectedErr: nil,
+			cleanup: func(_ *Driver) {
+				_ = os.RemoveAll("./false_is_likely_republish_clientid")
+			},
+		},
+		{
+			desc: "[Success] Republish for ephemeral clientID-based mount already mounted skips NodeStageVolume",
+			setup: func(_ *Driver) {
+				_ = makeDir("./false_is_likely_republish_ephemeral")
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "csi-ephemeral-clientid-republish-already-mounted",
+				TargetPath:        "./false_is_likely_republish_ephemeral",
+				StagingTargetPath: sourceTest,
+				Readonly:          true,
+				VolumeContext: map[string]string{
+					ephemeralField:      "true",
+					storageAccountField: "teststorageaccount",
+					containerNameField:  "testcontainer",
+					clientIDField:       "test-client-id-1234",
+				},
+			},
+			expectedErr: nil,
+			cleanup: func(_ *Driver) {
+				_ = os.RemoveAll("./false_is_likely_republish_ephemeral")
+			},
+		},
+		{
 			desc: "Volume already mounted",
 			setup: func(_ *Driver) {
 				// Create the directory and ensure it's seen as already mounted


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When a CSI volume is mounted with `requiresRepublish=true`, kubelet re-invokes `NodePublishVolume` every ~2 min. For clientID-based mounts, each republish triggered wasteful ARM API calls (`GetAccountInfo`/`ListKeys`) via `NodeStageVolume`, whose result was then discarded because `ensureMountPoint` short-circuited on the existing mount. At scale this drives ARM ListKeys throttling.

**Fix:** In both `NodePublishVolume` branches that would re-invoke `NodeStageVolume` on republish (SA-token path and ephemeral path), detect the case where the target path is already a mount point and short-circuit with a successful response.

The `mountWithWIToken` path is excluded so credential rotation (Kerberos ticket refresh) continues on every republish.

This is the blob CSI driver equivalent of https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3274.

**Which issue(s) this PR fixes:**
N/A

**Special notes for your reviewer:**
- Added `canSkipRepublishNodeStage` helper (same pattern as azurefile-csi-driver)
- Two new test cases cover the clientID-only and ephemeral republish skip paths