### PR TITLE
[release-1.26] fix: skip ReadDir health probe on NodePublishVolume republish (cherry-pick #2572)

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -128,6 +128,17 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		mountOptions = append(mountOptions, "ro")
 	}
 
+	// Skip the data-plane ReadDir(1) health probe on NodePublishVolume
+	// republish: the mount table entry is authoritative for the bind mount,
+	// and kubelet republishes every ~1min due to CSIDriver.spec.requiresRepublish=true.
+	// A per-republish ReadDir would translate into a ListBlobs REST call per
+	// pod-volume even when the workload is idle, which is expensive at scale.
+	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
+	if err == nil && !notMnt {
+		klog.V(2).Infof("NodePublishVolume: volume %s is already mounted on %s, skipping health probe", volumeID, target)
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
 	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", target, err)

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -133,10 +133,16 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	// and kubelet republishes every ~1min due to CSIDriver.spec.requiresRepublish=true.
 	// A per-republish ReadDir would translate into a ListBlobs REST call per
 	// pod-volume even when the workload is idle, which is expensive at scale.
-	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
-	if err == nil && !notMnt {
-		klog.V(2).Infof("NodePublishVolume: volume %s is already mounted on %s, skipping health probe", volumeID, target)
-		return &csi.NodePublishVolumeResponse{}, nil
+	// Use mounter.List() instead of IsLikelyNotMountPoint because the latter
+	// cannot detect bind mounts reliably.
+	if mountList, err := d.mounter.List(); err == nil {
+		targetAbs, _ := filepath.Abs(target)
+		for _, mp := range mountList {
+			if mp.Path == targetAbs {
+				klog.V(2).Infof("NodePublishVolume: volume %s is already mounted on %s, skipping health probe", volumeID, target)
+				return &csi.NodePublishVolumeResponse{}, nil
+			}
+		}
 	}
 
 	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions))

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -136,11 +136,13 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	// Use mounter.List() instead of IsLikelyNotMountPoint because the latter
 	// cannot detect bind mounts reliably.
 	if mountList, err := d.mounter.List(); err == nil {
-		targetAbs, _ := filepath.Abs(target)
-		for _, mp := range mountList {
-			if mp.Path == targetAbs {
-				klog.V(2).Infof("NodePublishVolume: volume %s is already mounted on %s, skipping health probe", volumeID, target)
-				return &csi.NodePublishVolumeResponse{}, nil
+		targetAbs, absErr := filepath.Abs(target)
+		if absErr == nil {
+			for _, mp := range mountList {
+				if mp.Path == targetAbs {
+					klog.V(2).Infof("NodePublishVolume: volume %s is already mounted on %s, skipping health probe", volumeID, target)
+					return &csi.NodePublishVolumeResponse{}, nil
+				}
 			}
 		}
 	}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -236,8 +236,13 @@ func TestNodePublishVolume(t *testing.T) {
 		},
 		{
 			desc: "[Success] Republish skips health probe when target is already mounted",
-			setup: func(_ *Driver) {
+			setup: func(d *Driver) {
 				_ = makeDir("./false_is_likely_republish")
+				// Populate the fake mount table so the List()-based check
+				// detects the bind mount and skips ensureMountPoint.
+				targetAbs, _ := filepath.Abs("./false_is_likely_republish")
+				fm := d.mounter.(*mount.SafeFormatAndMount).Interface.(*fakeMounter)
+				fm.MountPoints = append(fm.MountPoints, mount.MountPoint{Path: targetAbs})
 			},
 			req: &csi.NodePublishVolumeRequest{
 				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
@@ -247,8 +252,10 @@ func TestNodePublishVolume(t *testing.T) {
 				Readonly:          true,
 			},
 			expectedErr: nil,
-			cleanup: func(_ *Driver) {
+			cleanup: func(d *Driver) {
 				_ = os.RemoveAll("./false_is_likely_republish")
+				fm := d.mounter.(*mount.SafeFormatAndMount).Interface.(*fakeMounter)
+				fm.MountPoints = nil
 			},
 		},
 	}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -234,6 +234,23 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			expectedErr: status.Error(codes.InvalidArgument, fmt.Sprintf("invalid mountPermissions %s", "07ab")),
 		},
+		{
+			desc: "[Success] Republish skips health probe when target is already mounted",
+			setup: func(_ *Driver) {
+				_ = makeDir("./false_is_likely_republish")
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "vol_republish",
+				TargetPath:        "./false_is_likely_republish",
+				StagingTargetPath: sourceTest,
+				Readonly:          true,
+			},
+			expectedErr: nil,
+			cleanup: func(_ *Driver) {
+				_ = os.RemoveAll("./false_is_likely_republish")
+			},
+		},
 	}
 
 	// Setup

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -241,7 +241,7 @@ func TestNodePublishVolume(t *testing.T) {
 				// Populate the fake mount table so the List()-based check
 				// detects the bind mount and skips ensureMountPoint.
 				targetAbs, _ := filepath.Abs("./false_is_likely_republish")
-				fm := d.mounter.(*mount.SafeFormatAndMount).Interface.(*fakeMounter)
+				fm := d.mounter.Interface.(*fakeMounter)
 				fm.MountPoints = append(fm.MountPoints, mount.MountPoint{Path: targetAbs})
 			},
 			req: &csi.NodePublishVolumeRequest{
@@ -254,7 +254,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectedErr: nil,
 			cleanup: func(d *Driver) {
 				_ = os.RemoveAll("./false_is_likely_republish")
-				fm := d.mounter.(*mount.SafeFormatAndMount).Interface.(*fakeMounter)
+				fm := d.mounter.Interface.(*fakeMounter)
 				fm.MountPoints = nil
 			},
 		},


### PR DESCRIPTION
Cherry-picked from #2572 (master).

**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When kubelet republishes (`requiresRepublish=true`, every ~1min), `ensureMountPoint` issues a `ReadDir(1)` which translates into a `ListBlobs` REST call per pod-volume even when the workload is idle. At scale this drives unnecessary Azure Storage API traffic.

**Fix:** In `NodePublishVolume`, check if the target is already a mount point via `IsLikelyNotMountPoint` before calling `ensureMountPoint`. If already mounted, short-circuit with success — skipping the data-plane ReadDir health probe entirely.

**Cherry-pick adaptation for release-1.26:**
- release-1.26 `ensureMountPoint` does not have the `shouldUnmount` parameter (added on master), so the mount-point check is done at the `NodePublishVolume` level instead.

**Which issue(s) this PR fixes:**
Cherry-pick of #2572