### PR TITLE
fix: skip unmount in ensureMountPoint during NodePublishVolume republish (cherry-pick #2509)

### DIFF
--- a/pkg/blob/fake_mount.go
+++ b/pkg/blob/fake_mount.go
@@ -25,6 +25,7 @@ import (
 
 type fakeMounter struct {
 	mount.FakeMounter
+	unmountCount int
 }
 
 // Mount overrides mount.FakeMounter.Mount.
@@ -57,4 +58,10 @@ func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// Unmount overrides mount.FakeMounter.Unmount.
+func (f *fakeMounter) Unmount(target string) error {
+	f.unmountCount++
+	return nil
 }

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -128,7 +128,8 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		mountOptions = append(mountOptions, "ro")
 	}
 
-	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions))
+	// NodePublishVolume should not unmount during republish to prevent race conditions.
+	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions), false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", target, err)
 	}
@@ -334,7 +335,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: containerName must be specified for ephemeral volumes")
 	}
 
-	mnt, err := d.ensureMountPoint(targetPath, fs.FileMode(mountPermissions))
+	mnt, err := d.ensureMountPoint(targetPath, fs.FileMode(mountPermissions), true)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", targetPath, err)
 	}
@@ -691,7 +692,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 
 // ensureMountPoint: create mount point if not exists
 // return <true, nil> if it's already a mounted point otherwise return <false, nil>
-func (d *Driver) ensureMountPoint(target string, perm os.FileMode) (bool, error) {
+func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {
 		if IsCorruptedDir(target) {
@@ -739,14 +740,20 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode) (bool, error)
 			klog.V(2).Infof("already mounted to target %s", target)
 			return !notMnt, nil
 		}
-		// mount link is invalid, now unmount and remount later
-		klog.Warningf("ReadDir %s failed with %v, unmount this directory", target, err)
-		if err := d.mounter.Unmount(target); err != nil {
-			klog.Errorf("Unmount directory %s failed with %v", target, err)
+		if shouldUnmount {
+			// mount link is invalid, now unmount and remount later
+			klog.Warningf("ReadDir %s failed with %v, unmounting stale mount to fix it", target, err)
+			if err := d.mounter.Unmount(target); err != nil {
+				klog.Errorf("Unmount directory %s failed with %v", target, err)
+				return !notMnt, err
+			}
+			notMnt = true
 			return !notMnt, err
 		}
-		notMnt = true
-		return !notMnt, err
+		// shouldUnmount is false (NodePublishVolume republish path):
+		// report as already mounted and let NodeUnpublishVolume handle cleanup.
+		klog.Warningf("ReadDir %s failed with %v, but skipping unmount during republish", target, err)
+		return !notMnt, nil
 	}
 	if err := volumehelper.MakeDir(target, perm); err != nil {
 		klog.Errorf("MakeDir failed on target: %s (%v)", target, err)

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -128,7 +128,8 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		mountOptions = append(mountOptions, "ro")
 	}
 
-	// NodePublishVolume should not unmount during republish to prevent race conditions.
+	// Pass shouldUnmount=false: NodePublishVolume must not unmount a stale mount to
+	// prevent a race where the app container loses its volume mid-write.
 	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions), false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", target, err)
@@ -690,8 +691,12 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 	return resp, nil
 }
 
-// ensureMountPoint: create mount point if not exists
-// return <true, nil> if it's already a mounted point otherwise return <false, nil>
+// ensureMountPoint: create mount point if not exists.
+// When shouldUnmount is true (e.g. NodeStageVolume), a stale mount is unmounted so it can be
+// re-established. When shouldUnmount is false (e.g. NodePublishVolume), a stale mount is left
+// in place and the error is returned so kubelet can retry; this avoids a race where unmounting
+// during periodic republish causes data loss if the application container is writing.
+// Returns <true, nil> if already a healthy mounted point, otherwise <false, nil>.
 func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {
@@ -750,10 +755,10 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 			notMnt = true
 			return !notMnt, err
 		}
-		// shouldUnmount is false (NodePublishVolume republish path):
-		// report as already mounted and let NodeUnpublishVolume handle cleanup.
-		klog.Warningf("ReadDir %s failed with %v, but skipping unmount during republish", target, err)
-		return !notMnt, nil
+		// shouldUnmount is false: skip unmount to avoid data-loss race, but return
+		// the error so kubelet can surface the failure and retry.
+		klog.Warningf("ReadDir %s failed with %v, skipping unmount (shouldUnmount=false)", target, err)
+		return !notMnt, err
 	}
 	if err := volumehelper.MakeDir(target, perm); err != nil {
 		klog.Errorf("MakeDir failed on target: %s (%v)", target, err)

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -696,7 +696,11 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 // re-established. When shouldUnmount is false (e.g. NodePublishVolume), a stale mount is left
 // in place and the error is returned so kubelet can retry; this avoids a race where unmounting
 // during periodic republish causes data loss if the application container is writing.
-// Returns <true, nil> if already a healthy mounted point, otherwise <false, nil>.
+// Returns:
+//   - (true, nil) if the target is already a healthy mount point
+//   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
+//   - (false, nil) if the target was freshly created or successfully unmounted
+//   - (false, err) on other failures
 func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -127,7 +127,7 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := d.ensureMountPoint(test.target, 0777)
+		_, err := d.ensureMountPoint(test.target, 0777, true)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("[%s]: Unexpected Error: %v, expected error: %v", test.desc, err, test.expectedErr)
 		}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -133,8 +133,14 @@ func TestEnsureMountPoint(t *testing.T) {
 		}
 	}
 
+	// Test shouldUnmount=false: error is returned but unmount is not called.
+	_, err := d.ensureMountPoint(falseTarget, 0777, false)
+	if err == nil {
+		t.Errorf("[shouldUnmount=false] expected error for stale mount target, got nil")
+	}
+
 	// Clean up
-	err := os.RemoveAll(alreadyExistTarget)
+	err = os.RemoveAll(alreadyExistTarget)
 	assert.NoError(t, err)
 	err = os.RemoveAll(targetTest)
 	assert.NoError(t, err)

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -134,9 +134,13 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	// Test shouldUnmount=false: error is returned but unmount is not called.
+	unmountCountBefore := fakeMounter.unmountCount
 	_, err := d.ensureMountPoint(falseTarget, 0777, false)
 	if err == nil {
 		t.Errorf("[shouldUnmount=false] expected error for stale mount target, got nil")
+	}
+	if fakeMounter.unmountCount != unmountCountBefore {
+		t.Errorf("[shouldUnmount=false] expected no Unmount calls, but got %d", fakeMounter.unmountCount-unmountCountBefore)
 	}
 
 	// Clean up


### PR DESCRIPTION
Cherry-picked from #2509 (master).

**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When `requiresRepublish` is true, kubelet sends periodic `NodePublishVolume` calls. During these republish calls, `ensureMountPoint` was performing an unmount when it detected a stale or broken mount (ReadDir failure).

If the application container restarts at the same time as this unmount, writes to the mount path land on the container's local filesystem instead of the persistent volume, causing **silent data loss**.

Per the Kubernetes CSI documentation, when `requiresRepublish` is true, subsequent `NodePublishVolume` calls should only update the contents of the volume — not remount or alter mount state.

This change adds a `shouldUnmount` parameter to `ensureMountPoint`:
- `NodePublishVolume` passes `false` — a stale mount is left in place (no unmount) and the error is returned so kubelet can surface the failure and retry. This avoids the data-loss race where unmounting during periodic republish removes the volume out from under a writing container.
- `NodeStageVolume` passes `true` — a stale mount is unmounted so it can be re-established, as before.

Return value semantics of `ensureMountPoint(shouldUnmount=false)`:
- `(true, nil)` — target is a healthy mount, republish is a no-op
- `(true, err)` — target is mounted but health probe failed; unmount is skipped to avoid data loss, error is propagated so kubelet retries and monitoring surfaces the failure

**Cherry-pick notes:**
- release-1.26 lacks the csiMetrics block in `NodeStageVolume` — kept the simpler call, only added the new `true` argument.

**Which issue(s) this PR fixes:**
Cherry-pick of #2509