### PR TITLE
fix: prevent ARM throttling on kubelet requiresRepublish for clientID-based mounts (cherry-pick #2575)

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -82,6 +82,10 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	if context != nil {
 		// token request
 		if context[serviceAccountTokenField] != "" && useWorkloadIdentity(context) {
+			if d.canSkipRepublishNodeStage(context, target) {
+				klog.V(2).Infof("NodePublishVolume: volume(%s) already mounted on %s with clientID auth, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
+				return &csi.NodePublishVolumeResponse{}, nil
+			}
 			klog.V(2).Infof("NodePublishVolume: volume(%s) mount on %s with service account token, clientID: %s", volumeID, target, getValueInMap(context, clientIDField))
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 				StagingTargetPath: target,
@@ -99,6 +103,10 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 				// only get storage account from secret
 				setKeyValueInMap(context, getAccountKeyFromSecretField, trueValue)
 				setKeyValueInMap(context, storageAccountField, "")
+			}
+			if d.canSkipRepublishNodeStage(context, target) {
+				klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) already mounted on %s, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
+				return &csi.NodePublishVolumeResponse{}, nil
 			}
 			klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
@@ -867,4 +875,20 @@ func useWorkloadIdentity(attrib map[string]string) bool {
 		return true
 	}
 	return false
+}
+
+// canSkipRepublishNodeStage reports whether a NodePublishVolume call is a kubelet
+// requiresRepublish retry (target already mounted) whose auth mode has no time-bound
+// credential to refresh. When true, callers should return success without re-invoking
+// NodeStageVolume, avoiding wasteful ARM API calls (GetAccountInfo/ListKeys for
+// clientID-only mounts) whose result would be discarded because NodeStageVolume's
+// ensureMountPoint short-circuits on an existing mount.
+// The mountWithWIToken path is excluded so credential rotation continues on every
+// republish.
+func (d *Driver) canSkipRepublishNodeStage(context map[string]string, target string) bool {
+	if strings.EqualFold(getValueInMap(context, mountWithWITokenField), trueValue) {
+		return false
+	}
+	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
+	return err == nil && !notMnt
 }

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -881,12 +881,14 @@ func useWorkloadIdentity(attrib map[string]string) bool {
 // requiresRepublish retry (target already mounted) whose auth mode has no time-bound
 // credential to refresh. When true, callers should return success without re-invoking
 // NodeStageVolume, avoiding wasteful ARM API calls (GetAccountInfo/ListKeys for
-// clientID-only mounts) whose result would be discarded because NodeStageVolume's
-// ensureMountPoint short-circuits on an existing mount.
+// clientID-only mounts). Although NodeStageVolume would eventually return early
+// when it sees the mount is already present (mnt==true after ensureMountPoint),
+// it still performs GetAuthEnv and other setup work before that check — skipping
+// the call entirely avoids that overhead.
 // The mountWithWIToken path is excluded so credential rotation continues on every
 // republish.
-func (d *Driver) canSkipRepublishNodeStage(context map[string]string, target string) bool {
-	if strings.EqualFold(getValueInMap(context, mountWithWITokenField), trueValue) {
+func (d *Driver) canSkipRepublishNodeStage(volumeContext map[string]string, target string) bool {
+	if strings.EqualFold(getValueInMap(volumeContext, mountWithWITokenField), trueValue) {
 		return false
 	}
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -887,10 +887,22 @@ func useWorkloadIdentity(attrib map[string]string) bool {
 // the call entirely avoids that overhead.
 // The mountWithWIToken path is excluded so credential rotation continues on every
 // republish.
+//
+// A lightweight os.Lstat is used to detect stale/broken mounts (ENOTCONN, ESTALE)
+// so we don't mask failures by returning success on a dead mount.
 func (d *Driver) canSkipRepublishNodeStage(volumeContext map[string]string, target string) bool {
 	if strings.EqualFold(getValueInMap(volumeContext, mountWithWITokenField), trueValue) {
 		return false
 	}
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
-	return err == nil && !notMnt
+	if err != nil || notMnt {
+		return false
+	}
+	// Verify the mount is healthy: os.Lstat is served by the kernel VFS
+	// and returns ENOTCONN/ESTALE when the FUSE process died or the mount
+	// is broken, without issuing any data-plane request.
+	if _, err := os.Lstat(target); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -355,6 +355,52 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "[Success] Republish for clientID-only mount already mounted skips NodeStageVolume",
+			setup: func(_ *Driver) {
+				_ = makeDir("./false_is_likely_republish_clientid")
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "csi-clientid-republish-already-mounted",
+				TargetPath:        "./false_is_likely_republish_clientid",
+				StagingTargetPath: sourceTest,
+				Readonly:          true,
+				VolumeContext: map[string]string{
+					storageAccountField:      "teststorageaccount",
+					containerNameField:       "testcontainer",
+					clientIDField:            "test-client-id-1234",
+					serviceAccountTokenField: `{"api://AzureADTokenExchange":{"token":"test-token","expirationTimestamp":"2023-01-01T00:00:00Z"}}`,
+				},
+			},
+			expectedErr: nil,
+			cleanup: func(_ *Driver) {
+				_ = os.RemoveAll("./false_is_likely_republish_clientid")
+			},
+		},
+		{
+			desc: "[Success] Republish for ephemeral clientID-based mount already mounted skips NodeStageVolume",
+			setup: func(_ *Driver) {
+				_ = makeDir("./false_is_likely_republish_ephemeral")
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "csi-ephemeral-clientid-republish-already-mounted",
+				TargetPath:        "./false_is_likely_republish_ephemeral",
+				StagingTargetPath: sourceTest,
+				Readonly:          true,
+				VolumeContext: map[string]string{
+					ephemeralField:      "true",
+					storageAccountField: "teststorageaccount",
+					containerNameField:  "testcontainer",
+					clientIDField:       "test-client-id-1234",
+				},
+			},
+			expectedErr: nil,
+			cleanup: func(_ *Driver) {
+				_ = os.RemoveAll("./false_is_likely_republish_ephemeral")
+			},
+		},
+		{
 			desc: "Volume already mounted",
 			setup: func(_ *Driver) {
 				// Create the directory and ensure it's seen as already mounted


### PR DESCRIPTION
Cherry-picked from #2575 (master).

**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
With `requiresRepublish=true`, kubelet calls `NodePublishVolume` every ~1 minute. For clientID-based (workload identity) mounts, the current implementation re-invokes `NodeStageVolume` on every republish, which performs ARM API calls (`GetAccountInfo`/`ListKeys`) even though the result is discarded (`ensureMountPoint` short-circuits on an existing mount). At scale this causes ARM throttling.

**Fix:** Add `canSkipRepublishNodeStage` helper. When the target is already mounted, the mount is healthy (`os.Lstat` succeeds — detects ENOTCONN/ESTALE), and it's not the `mountWithWIToken` path (which needs credential rotation), skip the `NodeStageVolume` call entirely.

**Cherry-pick notes for release-1.27:**
- release-1.27 uses `context[serviceAccountTokenField]` directly instead of the newer `serviceAccountTokens` variable / `getServiceAccountTokens` helper (which was added later on master). The skip-check was adapted to the existing code shape.
- `getServiceAccountTokens` helper is not included — not needed for this release.

**Which issue(s) this PR fixes:**
Cherry-pick of #2575