### PR TITLE
Cherry pick #2573 into release-1.27: use syscall.Statfs instead of ReadDir for mount health probe

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -205,8 +205,8 @@ def get_regexs():
     # dates can be 2014, 2015, 2016, ..., CURRENT_YEAR, company holder names can be anything
     years = range(2014, date.today().year + 1)
     regexs["date"] = re.compile( '(%s)' % "|".join(map(lambda l: str(l), years)) )
-    # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    # strip //go:build and // +build \n\n build constraints
+    regexs["go_build_constraints"] = re.compile(r"^(//go:build.*\n|// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     # Search for generated files

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -18,7 +18,6 @@ package blob
 
 import (
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -758,10 +757,20 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 }
 
 // ensureMountPoint: create mount point if not exists.
-// When shouldUnmount is true (e.g. NodeStageVolume), a stale mount is unmounted so it can be
-// re-established. When shouldUnmount is false (e.g. NodePublishVolume), a stale mount is left
-// in place and the error is returned so kubelet can retry; this avoids a race where unmounting
-// during periodic republish causes data loss if the application container is writing.
+//
+// Uses a lightweight kernel-level probe (probeMount) to detect stale mounts.
+// On Linux this calls syscall.Statfs, which is served entirely by the kernel
+// FUSE layer without issuing any data-plane request to Azure Blob Storage.
+// On Windows it uses os.Lstat. Both detect the failure modes that matter:
+// ENOTCONN (blobfuse died), ESTALE, EIO.
+//
+// When shouldUnmount is true (NodeStageVolume path), a failed probe triggers
+// an unmount so the mount can be recreated by the caller.
+//
+// When shouldUnmount is false (NodePublishVolume republish path), a failed
+// probe returns the error without unmounting to avoid a data-loss race where
+// unmounting during periodic republish would truncate writes in flight.
+//
 // Returns:
 //   - (true, nil) if the target is already a healthy mount point
 //   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
@@ -798,26 +807,23 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 	}
 
 	if !notMnt {
-		// testing original mount point, make sure the mount link is valid
-		// Use ReadDir(1) instead of full os.ReadDir to avoid expensive directory listing
-		// on blobfuse mounts with many files. ReadDir(1) makes only one BlockBlob.List()
-		// call (returning up to 5000 entries) regardless of directory size.
-		f, err := os.Open(target)
-		if err == nil {
-			defer f.Close()
-			_, err = f.ReadDir(1)
-			// EOF means empty directory, which is valid
-			if err == io.EOF {
-				err = nil
-			}
-		}
+		// testing original mount point, make sure the mount link is valid.
+		// Use a cheap kernel-level probe (probeMount) instead of ReadDir(1):
+		// on Linux this calls syscall.Statfs which is served entirely by the
+		// kernel FUSE layer, so it does not issue any data-plane request to
+		// Azure Blob Storage. ReadDir would translate into a BlockBlob.List()
+		// (ListBlobs) REST call which is expensive on large containers and
+		// adds unnecessary load on every mount health probe. The Statfs-based
+		// check still detects the failure modes we care about (ENOTCONN when
+		// the blobfuse process died, ESTALE, EIO on a broken mount).
+		err := probeMount(target)
 		if err == nil {
 			klog.V(2).Infof("already mounted to target %s", target)
 			return !notMnt, nil
 		}
 		if shouldUnmount {
 			// mount link is invalid, now unmount and remount later
-			klog.Warningf("ReadDir %s failed with %v, unmounting stale mount to fix it", target, err)
+			klog.Warningf("probeMount %s failed with %v, unmounting stale mount to fix it", target, err)
 			if err := d.mounter.Unmount(target); err != nil {
 				klog.Errorf("Unmount directory %s failed with %v", target, err)
 				return !notMnt, err
@@ -827,7 +833,7 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 		}
 		// shouldUnmount is false: skip unmount to avoid data-loss race, but return
 		// the error so kubelet can surface the failure and retry.
-		klog.Warningf("ReadDir %s failed with %v, skipping unmount (shouldUnmount=false)", target, err)
+		klog.Warningf("probeMount %s failed with %v, skipping unmount (shouldUnmount=false)", target, err)
 		return !notMnt, err
 	}
 	if err := volumehelper.MakeDir(target, perm); err != nil {

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -100,7 +100,7 @@ func TestEnsureMountPoint(t *testing.T) {
 		{
 			desc:        "[Error] Error opening file",
 			target:      falseTarget,
-			expectedErr: &os.PathError{Op: "open", Path: "./false_is_likely_target", Err: syscall.ENOENT},
+			expectedErr: syscall.ENOENT,
 		},
 		{
 			desc:        "[Error] Not a directory",

--- a/pkg/blob/nodeserver_unix.go
+++ b/pkg/blob/nodeserver_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import "syscall"
+
+// probeMount performs a lightweight mount-liveness check on target.
+//
+// It uses syscall.Statfs, which is served by the kernel FUSE layer without
+// issuing any data-plane request to Azure Blob Storage, while still surfacing
+// the failure modes we care about (ENOTCONN when the blobfuse process died,
+// ESTALE, EIO on a broken mount).
+func probeMount(target string) error {
+	var stat syscall.Statfs_t
+	return syscall.Statfs(target, &stat)
+}

--- a/pkg/blob/nodeserver_windows.go
+++ b/pkg/blob/nodeserver_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// probeMount performs a lightweight mount-liveness check on target.
+//
+// blobfuse itself is Linux-only; on Windows the driver runs against SMB via
+// csi-proxy and there is no FUSE mount to probe. Fall back to os.Lstat, which
+// is a cheap kernel-level check that still detects a missing or broken
+// target path. We unwrap the PathError to return the underlying syscall
+// errno directly, keeping behavior consistent with the Linux Statfs path.
+func probeMount(target string) error {
+	_, err := os.Lstat(target)
+	if err != nil {
+		var errno syscall.Errno
+		if errors.As(err, &errno) {
+			return errno
+		}
+	}
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

Cherry-pick of #2573 (`fix: use syscall.Statfs instead of ReadDir for mount health probe`) into `release-1.27`.

`ensureMountPoint`'s liveness check on `release-1.27` currently uses `os.Open` + `ReadDir(1)`, which on a blobfuse mount translates to a `BlockBlob.List()` (ListBlobs) REST call against Azure Blob Storage on every `NodeStageVolume`. This is unnecessarily expensive for a mount-liveness probe. Replace it with the kernel-level `probeMount()` helper introduced in #2573:

- Linux (`nodeserver_unix.go`): `syscall.Statfs` on the mount root — served entirely by the kernel FUSE layer, no data-plane request to Azure Blob Storage.
- Windows (`nodeserver_windows.go`): `os.Lstat` fallback (no FUSE on Windows).
- Still detects the failure modes we care about: `ENOTCONN` when the blobfuse process died, `ESTALE`, `EIO` on a broken mount.
- Follows the same pattern used by the GCS FUSE CSI driver.

Also carries over the boilerplate check update (`hack/boilerplate/boilerplate.py`) so `//go:build` lines are stripped before the license comparison.

**Conflict resolution notes:**
`release-1.27` does not have PR #2572 ("skip ReadDir health probe on NodePublishVolume republish"). The release-1.27 version of `ensureMountPoint` keeps the existing `shouldUnmount` split (unmount on NodeStage, skip unmount on NodePublish to avoid a data-loss race) and only swaps the ReadDir(1) probe body for `probeMount(target)`, plus updates the log messages from `ReadDir` → `probeMount`. Doc comment reworded to match the cherry-picked implementation.

**Which issue(s) this PR fixes:**

Cherry-pick of #2573 into release-1.27.

**Special notes for your reviewer:**

- `gofmt` clean.
- `probeMount` is defined in the new `nodeserver_unix.go` / `nodeserver_windows.go` files added by this cherry-pick.

**Release note:**

```release-note
fix: use syscall.Statfs instead of ReadDir for mount health probe in ensureMountPoint, avoiding a per-NodeStageVolume ListBlobs REST call against Azure Blob Storage.
```