### PR TITLE
docs(charts): add GitHub Pages as alternate helm repo source

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -19,8 +19,26 @@
     - `--set linux.kubelet="/var/snap/microk8s/common/var/lib/kubelet"` - sets correct path to microk8s kubelet even though a user has a folder link to it.
 
 ### install a specific version
+
+Add the helm repo — pick **one** source (both host the same charts; do not run both, the second overwrites the first):
+
+Option 1: raw.githubusercontent.com (default)
+
 ```console
 helm repo add blob-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/blob-csi-driver/master/charts
+```
+
+Option 2: GitHub Pages mirror (available since 1.26.12, not affected by raw.githubusercontent.com rate limits)
+
+```console
+helm repo add blob-csi-driver https://kubernetes-sigs.github.io/blob-csi-driver
+```
+
+Then update the repo cache, search for available versions, and install:
+
+```console
+helm repo update blob-csi-driver
+helm search repo blob-csi-driver --versions
 helm install blob-csi-driver blob-csi-driver/blob-csi-driver --set node.enableBlobfuseProxy=true --namespace kube-system --version 1.27.8
 ```
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -20,7 +20,7 @@
 
 ### install a specific version
 
-Add the helm repo — pick **one** source (both host the same charts; do not run both, the second overwrites the first):
+Add the helm repo — pick **one** source (both host the same charts; the two commands share the repo name `blob-csi-driver`, so running the second after the first will fail unless you pass `--force-update`):
 
 Option 1: raw.githubusercontent.com (default)
 


### PR DESCRIPTION
## What this PR does

Documents `https://kubernetes-sigs.github.io/blob-csi-driver` as an alternate helm repository source alongside the existing `raw.githubusercontent.com` source in `charts/README.md`.

Both sources host the same charts. The GitHub Pages mirror is not affected by `raw.githubusercontent.com` rate limits and is available starting from chart version **1.26.12** (the first version published by the workflow added in #2592).

## Why

`raw.githubusercontent.com` is aggressively rate-limited from shared IPs (CI runners, corporate NAT, etc.). Offering a GitHub Pages mirror gives users an unrate-limited alternative without breaking the existing installation path.

## Changes

- `charts/README.md`: replace the single `helm repo add` block under **install a specific version** with two separate code blocks (one per source), plus an explicit "pick **one**" note so users don't accidentally run both (which would silently overwrite the first repo with the second since they share the same `blob-csi-driver` repo name)
- Also add `helm repo update blob-csi-driver` + `helm search repo blob-csi-driver --versions` to the install snippet for consistency 

Fixes #2331

/kind documentation
/sig storage
/assign @andyzhangx