### PR TITLE
feat: support data plane API using OAuth for blob container operations

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -109,7 +109,7 @@ volumeAttributes.subscriptionID | specify Azure subscription ID where blob stora
 volumeAttributes.resourceGroup | Azure resource group name | existing resource group name | No | if empty, driver will use the same resource group name as current k8s cluster
 volumeAttributes.storageAccount | existing storage account name | existing storage account name | Yes |
 volumeAttributes.containerName | existing container name | existing container name | Yes |
-volumeAttributes.protocol | specify blobfuse, blobfuse2 or NFSv3 mount (blobfuse2 is still in Preview) | `fuse`, `fuse2`, `nfs` | No | `fuse`
+volumeAttributes.protocol | specify blobfuse, blobfuse2 or NFSv3 mount | `fuse`, `fuse2`, `nfs` | No | `fuse`
 volumeAttributes.server | specify Azure storage account server address | existing server address, e.g. `accountname.blob.core.windows.net` | No | if empty, driver will use default `accountname.blob.core.windows.net` or other sovereign cloud account address
 volumeAttributes.storageEndpointSuffix | specify Azure storage endpoint suffix | `core.windows.net`, `core.chinacloudapi.cn`, etc | No | if empty, driver will use default storage endpoint suffix according to cloud environment
 --- | **Following parameters are only for blobfuse** | --- | --- |
@@ -162,6 +162,10 @@ kubectl create secret generic azure-secret --from-literal azurestoragespnclients
  - blobfuse cache(`--tmp-path` [mount option](https://github.com/Azure/azure-storage-fuse/tree/blobfuse-1.4.5#mount-options))
    - By default, the blobfuse cache is located in the `/mnt` directory. If the VM SKU provides a temporary disk, the `/mnt` directory is mounted on the temporary disk. However, if the VM SKU does not provide a temporary disk, the `/mnt` directory is mounted on the OS disk. 
    - with blobfuse-proxy deployment (default on AKS), user could set `--tmp-path=` mount option to specify a different cache directory
+ - blobfuse2 attribute cache and kernel list cache tuning (requires blobfuse2 v2.5.4+, shipped by default)
+   - `--attr-cache-max-size-mb=<sizeInMB>`: maximum memory in MB that the attribute cache can use (`0` = auto-tune to 1% of total RAM, clamped to `[64 MB, 1 GB]`). Increase for workloads with large directory trees or many distinct file paths.
+   - `--kernel-list-cache-timeout=<seconds>`: enable kernel caching of directory listings and set the TTL in seconds (fuse3 only). `0` = disabled. Reduces backend `readdir` traffic for read-heavy workloads.
+   - Both are passed via `mountOptions` on the PV/StorageClass, and are also permitted on ephemeral inline volumes.
  - If there are CVEs in the `livenessprobe` and `csi-node-driver-registrar` sidecar images, you can run `kubectl edit ds -n kube-system csi-blob-node` to change the `imagePullPolicy` to `Always` for both sidecar containers. This will cause the CSI driver to restart and pull the latest patched images, thereby resolving the CVEs in these sidecar components.
  - [Mount Azure blob storage with managed identity](../deploy/example/blobfuse-mi)
  - [Blobfuse Performance and caching](https://github.com/Azure/azure-storage-fuse?tab=readme-ov-file#frequently-asked-questions)

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -60,7 +60,7 @@ requireInfraEncryption | specify whether or not the service applies a secondary 
 storageEndpointSuffix | specify Azure storage endpoint suffix | `core.windows.net`, `core.chinacloudapi.cn`, etc | No | if empty, driver will use default storage endpoint suffix according to cloud environment
 tags | [tags](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources) would be created in newly created storage account | tag format: 'foo=aaa,bar=bbb' | No | ""
 matchTags | whether matching tags when driver tries to find a suitable storage account | `true`,`false` | No | `false`
-useDataPlaneAPI | specify whether use data plane API for blob container create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account | `true`,`false` | No | `false`
+useDataPlaneAPI | specify whether use data plane API for blob container create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit. When set to `oauth`, the driver uses its managed-identity OAuth token (via `d.cloud.AuthProvider.GetAzIdentity()`) to perform container operations against the storage data plane, enabling access to storage accounts with firewall/vnet restrictions when `networkAcls.bypass` includes `AzureServices` | `true`,`false`,`oauth` | No | `false`
 softDeleteBlobs | Enable [soft delete for blobs](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-blob-overview), specify the days to retain deleted blobs | "7" | No | Soft Delete Blobs is disabled if empty
 softDeleteContainers | Enable [soft delete for containers](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-container-overview), specify the days to retain deleted containers | "7" | No | Soft Delete Containers is disabled if empty
 enableBlobVersioning | Enable [blob versioning](https://learn.microsoft.com/en-us/azure/storage/blobs/versioning-overview), can't enabled when `protocol` is `nfs` or `isHnsEnabled` is `true` | `true`,`false` | No | versioning for blobs is disabled if empty
@@ -179,3 +179,26 @@ kubectl create secret generic azure-secret --from-literal azurestoragespnclients
 
 #### [Storage considerations for Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/storage)
 #### [Compare access to Azure Files, Blob Storage, and Azure NetApp Files with NFS](https://learn.microsoft.com/en-us/azure/storage/common/nfs-comparison#comparison)
+
+#### Using `useDataPlaneAPI: oauth` against private storage accounts
+When `useDataPlaneAPI` is set to `oauth` in the StorageClass parameters, the blob CSI driver uses its own managed-identity OAuth token to perform container create/delete operations directly against the Azure Blob Storage data plane endpoint. This enables the driver to work with storage accounts that have:
+- `publicNetworkAccess` set to `Disabled`
+- Firewall/VNet restrictions configured
+- `networkAcls.bypass` including `AzureServices` (trusted service bypass)
+
+**Required RBAC role**: The driver's managed identity must be assigned the `Storage Blob Data Contributor` role (or higher) on the target storage account.
+
+**Example StorageClass**:
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: blob-fuse-private
+provisioner: blob.csi.azure.com
+parameters:
+  useDataPlaneAPI: "oauth"
+  storageAccount: mystorageaccount
+  resourceGroup: myResourceGroup
+```
+
+**Note**: When `useDataPlaneAPI: oauth` is set, the driver does not need storage account keys for container CRUD operations. The node-side mount operations (blobfuse/blobfuse2) still use their own authentication mechanism (workload identity, managed identity, etc.) as configured separately.

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -60,7 +60,7 @@ requireInfraEncryption | specify whether or not the service applies a secondary 
 storageEndpointSuffix | specify Azure storage endpoint suffix | `core.windows.net`, `core.chinacloudapi.cn`, etc | No | if empty, driver will use default storage endpoint suffix according to cloud environment
 tags | [tags](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources) would be created in newly created storage account | tag format: 'foo=aaa,bar=bbb' | No | ""
 matchTags | whether matching tags when driver tries to find a suitable storage account | `true`,`false` | No | `false`
-useDataPlaneAPI | specify whether use data plane API for blob container create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit. When set to `oauth`, the driver uses its managed-identity OAuth token (via `d.cloud.AuthProvider.GetAzIdentity()`) to perform container operations against the storage data plane, enabling access to storage accounts with firewall/vnet restrictions when `networkAcls.bypass` includes `AzureServices` | `true`,`false`,`oauth` | No | `false`
+useDataPlaneAPI | specify whether use data plane API for blob container create/delete, this could solve the SRP API throttling issue since data plane API has almost no limit, while it would fail when there is firewall or vnet setting on storage account | `true`,`false` | No | `false`
 softDeleteBlobs | Enable [soft delete for blobs](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-blob-overview), specify the days to retain deleted blobs | "7" | No | Soft Delete Blobs is disabled if empty
 softDeleteContainers | Enable [soft delete for containers](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-container-overview), specify the days to retain deleted containers | "7" | No | Soft Delete Containers is disabled if empty
 enableBlobVersioning | Enable [blob versioning](https://learn.microsoft.com/en-us/azure/storage/blobs/versioning-overview), can't enabled when `protocol` is `nfs` or `isHnsEnabled` is `true` | `true`,`false` | No | versioning for blobs is disabled if empty
@@ -109,7 +109,7 @@ volumeAttributes.subscriptionID | specify Azure subscription ID where blob stora
 volumeAttributes.resourceGroup | Azure resource group name | existing resource group name | No | if empty, driver will use the same resource group name as current k8s cluster
 volumeAttributes.storageAccount | existing storage account name | existing storage account name | Yes |
 volumeAttributes.containerName | existing container name | existing container name | Yes |
-volumeAttributes.protocol | specify blobfuse, blobfuse2 or NFSv3 mount | `fuse`, `fuse2`, `nfs` | No | `fuse`
+volumeAttributes.protocol | specify blobfuse, blobfuse2 or NFSv3 mount (blobfuse2 is still in Preview) | `fuse`, `fuse2`, `nfs` | No | `fuse`
 volumeAttributes.server | specify Azure storage account server address | existing server address, e.g. `accountname.blob.core.windows.net` | No | if empty, driver will use default `accountname.blob.core.windows.net` or other sovereign cloud account address
 volumeAttributes.storageEndpointSuffix | specify Azure storage endpoint suffix | `core.windows.net`, `core.chinacloudapi.cn`, etc | No | if empty, driver will use default storage endpoint suffix according to cloud environment
 --- | **Following parameters are only for blobfuse** | --- | --- |
@@ -162,10 +162,6 @@ kubectl create secret generic azure-secret --from-literal azurestoragespnclients
  - blobfuse cache(`--tmp-path` [mount option](https://github.com/Azure/azure-storage-fuse/tree/blobfuse-1.4.5#mount-options))
    - By default, the blobfuse cache is located in the `/mnt` directory. If the VM SKU provides a temporary disk, the `/mnt` directory is mounted on the temporary disk. However, if the VM SKU does not provide a temporary disk, the `/mnt` directory is mounted on the OS disk. 
    - with blobfuse-proxy deployment (default on AKS), user could set `--tmp-path=` mount option to specify a different cache directory
- - blobfuse2 attribute cache and kernel list cache tuning (requires blobfuse2 v2.5.4+, shipped by default)
-   - `--attr-cache-max-size-mb=<sizeInMB>`: maximum memory in MB that the attribute cache can use (`0` = auto-tune to 1% of total RAM, clamped to `[64 MB, 1 GB]`). Increase for workloads with large directory trees or many distinct file paths.
-   - `--kernel-list-cache-timeout=<seconds>`: enable kernel caching of directory listings and set the TTL in seconds (fuse3 only). `0` = disabled. Reduces backend `readdir` traffic for read-heavy workloads.
-   - Both are passed via `mountOptions` on the PV/StorageClass, and are also permitted on ephemeral inline volumes.
  - If there are CVEs in the `livenessprobe` and `csi-node-driver-registrar` sidecar images, you can run `kubectl edit ds -n kube-system csi-blob-node` to change the `imagePullPolicy` to `Always` for both sidecar containers. This will cause the CSI driver to restart and pull the latest patched images, thereby resolving the CVEs in these sidecar components.
  - [Mount Azure blob storage with managed identity](../deploy/example/blobfuse-mi)
  - [Blobfuse Performance and caching](https://github.com/Azure/azure-storage-fuse?tab=readme-ov-file#frequently-asked-questions)
@@ -179,26 +175,3 @@ kubectl create secret generic azure-secret --from-literal azurestoragespnclients
 
 #### [Storage considerations for Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/app-platform/aks/storage)
 #### [Compare access to Azure Files, Blob Storage, and Azure NetApp Files with NFS](https://learn.microsoft.com/en-us/azure/storage/common/nfs-comparison#comparison)
-
-#### Using `useDataPlaneAPI: oauth` against private storage accounts
-When `useDataPlaneAPI` is set to `oauth` in the StorageClass parameters, the blob CSI driver uses its own managed-identity OAuth token to perform container create/delete operations directly against the Azure Blob Storage data plane endpoint. This enables the driver to work with storage accounts that have:
-- `publicNetworkAccess` set to `Disabled`
-- Firewall/VNet restrictions configured
-- `networkAcls.bypass` including `AzureServices` (trusted service bypass)
-
-**Required RBAC role**: The driver's managed identity must be assigned the `Storage Blob Data Contributor` role (or higher) on the target storage account.
-
-**Example StorageClass**:
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: blob-fuse-private
-provisioner: blob.csi.azure.com
-parameters:
-  useDataPlaneAPI: "oauth"
-  storageAccount: mystorageaccount
-  resourceGroup: myResourceGroup
-```
-
-**Note**: When `useDataPlaneAPI: oauth` is set, the driver does not need storage account keys for container CRUD operations. The node-side mount operations (blobfuse/blobfuse2) still use their own authentication mechanism (workload identity, managed identity, etc.) as configured separately.

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -393,6 +393,8 @@ type Driver struct {
 	volMap sync.Map
 	// a timed cache storing all volumeIDs and storage accounts that are using data plane API
 	dataPlaneAPIVolCache azcache.Resource
+	// a timed cache storing resolved storage endpoint suffixes by volumeID/accountName
+	storageEndpointSuffixCache azcache.Resource
 	// a timed cache storing account search history (solve account list throttling issue)
 	accountSearchCache azcache.Resource
 	// a timed cache storing volume stats <volumeID, volumeStats>
@@ -453,6 +455,9 @@ func NewDriver(options *DriverOptions, kubeClient kubernetes.Interface, cloud *s
 		klog.Fatalf("%v", err)
 	}
 	if d.dataPlaneAPIVolCache, err = azcache.NewTimedCache(24*30*time.Hour, getter, false); err != nil {
+		klog.Fatalf("%v", err)
+	}
+	if d.storageEndpointSuffixCache, err = azcache.NewTimedCache(24*30*time.Hour, getter, false); err != nil {
 		klog.Fatalf("%v", err)
 	}
 	if d.azcopySasTokenCache, err = azcache.NewTimedCache(15*time.Minute, getter, false); err != nil {
@@ -1266,6 +1271,24 @@ func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName stri
 		return normalize(cache)
 	}
 	return ""
+}
+
+func (d *Driver) resolvedStorageEndpointSuffix(ctx context.Context, volumeID, accountName string) string {
+	cache, err := d.storageEndpointSuffixCache.Get(ctx, volumeID, azcache.CacheReadTypeDefault)
+	if err != nil {
+		klog.Errorf("get(%s) from storageEndpointSuffixCache failed with error: %v", volumeID, err)
+	}
+	if v, ok := cache.(string); ok && v != "" {
+		return v
+	}
+	cache, err = d.storageEndpointSuffixCache.Get(ctx, accountName, azcache.CacheReadTypeDefault)
+	if err != nil {
+		klog.Errorf("get(%s) from storageEndpointSuffixCache failed with error: %v", accountName, err)
+	}
+	if v, ok := cache.(string); ok && v != "" {
+		return v
+	}
+	return d.getStorageEndPointSuffix()
 }
 
 // ValidateMountArgValues checks that no value in the mountOptions slice contains

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1228,25 +1228,42 @@ func (d *Driver) getSubnetResourceID(vnetResourceGroup, vnetName, subnetName str
 }
 
 func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName string) string {
+	normalize := func(cache any) string {
+		if cache == nil {
+			return ""
+		}
+		if v, ok := cache.(string); ok {
+			switch {
+			case v == "":
+				return trueValue
+			case strings.EqualFold(v, trueValue):
+				return trueValue
+			case strings.EqualFold(v, falseValue):
+				return falseValue
+			case strings.EqualFold(v, oauth):
+				return oauth
+			default:
+				// Legacy cache entries only relied on presence to mean "enabled".
+				// Preserve that behavior for any non-empty unknown string.
+				return trueValue
+			}
+		}
+		return trueValue
+	}
+
 	cache, err := d.dataPlaneAPIVolCache.Get(ctx, volumeID, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("get(%s) from dataPlaneAPIVolCache failed with error: %v", volumeID, err)
 	}
 	if cache != nil {
-		if v, ok := cache.(string); ok && v != "" {
-			return v
-		}
-		return trueValue
+		return normalize(cache)
 	}
 	cache, err = d.dataPlaneAPIVolCache.Get(ctx, accountName, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("get(%s) from dataPlaneAPIVolCache failed with error: %v", accountName, err)
 	}
 	if cache != nil {
-		if v, ok := cache.(string); ok && v != "" {
-			return v
-		}
-		return trueValue
+		return normalize(cache)
 	}
 	return ""
 }

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -131,6 +131,8 @@ const (
 	fsGroupChangePolicyField         = "fsgroupchangepolicy"
 	useDataPlaneAPIField             = "usedataplaneapi"
 
+	oauth = "oauth"
+
 	// See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
 	containerNameMinLength = 3
 	containerNameMaxLength = 63
@@ -1225,22 +1227,28 @@ func (d *Driver) getSubnetResourceID(vnetResourceGroup, vnetName, subnetName str
 	return fmt.Sprintf(subnetTemplate, subsID, vnetResourceGroup, vnetName, subnetName)
 }
 
-func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName string) bool {
+func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName string) string {
 	cache, err := d.dataPlaneAPIVolCache.Get(ctx, volumeID, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("get(%s) from dataPlaneAPIVolCache failed with error: %v", volumeID, err)
 	}
 	if cache != nil {
-		return true
+		if v, ok := cache.(string); ok && v != "" {
+			return v
+		}
+		return trueValue
 	}
 	cache, err = d.dataPlaneAPIVolCache.Get(ctx, accountName, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("get(%s) from dataPlaneAPIVolCache failed with error: %v", accountName, err)
 	}
 	if cache != nil {
-		return true
+		if v, ok := cache.(string); ok && v != "" {
+			return v
+		}
+		return trueValue
 	}
-	return false
+	return ""
 }
 
 // ValidateMountArgValues checks that no value in the mountOptions slice contains

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -58,6 +58,7 @@ const (
 	blobCSIDriverName                = "blob_csi_driver"
 	separator                        = "#"
 	volumeIDTemplate                 = "%s#%s#%s#%s#%s#%s"
+	volumeIDOAuthMetadataTemplate    = "%s#%s#%s"
 	secretNameTemplate               = "azure-storage-account-%s-secret"
 	serverNameField                  = "server"
 	storageEndpointSuffixField       = "storageendpointsuffix"
@@ -1232,6 +1233,18 @@ func (d *Driver) getSubnetResourceID(vnetResourceGroup, vnetName, subnetName str
 	return fmt.Sprintf(subnetTemplate, subsID, vnetResourceGroup, vnetName, subnetName)
 }
 
+func parseVolumeIDMetadata(volumeID string) (string, string) {
+	segments := strings.Split(volumeID, separator)
+	if len(segments) > 7 {
+		return segments[6], segments[7]
+	}
+	return "", ""
+}
+
+func withOAuthVolumeIDMetadata(volumeID, storageEndpointSuffix string) string {
+	return fmt.Sprintf(volumeIDOAuthMetadataTemplate, volumeID, storageEndpointSuffix, oauth)
+}
+
 func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName string) string {
 	normalize := func(cache any) string {
 		if cache == nil {
@@ -1256,6 +1269,10 @@ func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName stri
 		return trueValue
 	}
 
+	if _, volumeIDUseDataPlaneAPI := parseVolumeIDMetadata(volumeID); volumeIDUseDataPlaneAPI != "" {
+		return normalize(volumeIDUseDataPlaneAPI)
+	}
+
 	cache, err := d.dataPlaneAPIVolCache.Get(ctx, volumeID, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("get(%s) from dataPlaneAPIVolCache failed with error: %v", volumeID, err)
@@ -1274,6 +1291,10 @@ func (d *Driver) useDataPlaneAPI(ctx context.Context, volumeID, accountName stri
 }
 
 func (d *Driver) resolvedStorageEndpointSuffix(ctx context.Context, volumeID, accountName string) string {
+	if storageEndpointSuffix, _ := parseVolumeIDMetadata(volumeID); storageEndpointSuffix != "" {
+		return storageEndpointSuffix
+	}
+
 	cache, err := d.storageEndpointSuffixCache.Get(ctx, volumeID, azcache.CacheReadTypeDefault)
 	if err != nil {
 		klog.Errorf("get(%s) from storageEndpointSuffixCache failed with error: %v", volumeID, err)

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1413,13 +1413,24 @@ func TestUseDataPlaneAPI(t *testing.T) {
 		testFunc func(t *testing.T)
 	}{
 		{
-			name: "volumeID loads correctly",
+			name: "volumeID loads correctly with true value",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				d.dataPlaneAPIVolCache.Set(fakeVolumeID, "foo")
+				d.dataPlaneAPIVolCache.Set(fakeVolumeID, trueValue)
 				output := d.useDataPlaneAPI(ctx, fakeVolumeID, "")
-				if !output {
-					t.Errorf("Actual Output: %t, Expected Output: %t", output, true)
+				if output != trueValue {
+					t.Errorf("Actual Output: %s, Expected Output: %s", output, trueValue)
+				}
+			},
+		},
+		{
+			name: "volumeID loads correctly with oauth value",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.dataPlaneAPIVolCache.Set(fakeVolumeID, oauth)
+				output := d.useDataPlaneAPI(ctx, fakeVolumeID, "")
+				if output != oauth {
+					t.Errorf("Actual Output: %s, Expected Output: %s", output, oauth)
 				}
 			},
 		},
@@ -1428,19 +1439,30 @@ func TestUseDataPlaneAPI(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
 				d.dataPlaneAPIVolCache.Set(fakeAccountName, "foo")
-				output := d.useDataPlaneAPI(ctx, fakeAccountName, "")
-				if !output {
-					t.Errorf("Actual Output: %t, Expected Output: %t", output, true)
+				output := d.useDataPlaneAPI(ctx, "", fakeAccountName)
+				if output == "" {
+					t.Errorf("Expected non-empty output when account is in cache")
 				}
 			},
 		},
 		{
-			name: "invalid volumeID and account",
+			name: "empty cache returns empty string",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
 				output := d.useDataPlaneAPI(ctx, "", "")
-				if output {
-					t.Errorf("Actual Output: %t, Expected Output: %t", output, false)
+				if output != "" {
+					t.Errorf("Actual Output: %s, Expected Output: empty string", output)
+				}
+			},
+		},
+		{
+			name: "legacy empty-string cache value returns true",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.dataPlaneAPIVolCache.Set(fakeVolumeID, "")
+				output := d.useDataPlaneAPI(ctx, fakeVolumeID, "")
+				if output != trueValue {
+					t.Errorf("Actual Output: %s, Expected Output: %s (legacy empty cache should return true)", output, trueValue)
 				}
 			},
 		},

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1435,13 +1435,13 @@ func TestUseDataPlaneAPI(t *testing.T) {
 			},
 		},
 		{
-			name: "account loads correctly",
+			name: "account cache legacy non-empty value returns true",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
 				d.dataPlaneAPIVolCache.Set(fakeAccountName, "foo")
 				output := d.useDataPlaneAPI(ctx, "", fakeAccountName)
-				if output == "" {
-					t.Errorf("Expected non-empty output when account is in cache")
+				if output != trueValue {
+					t.Errorf("Actual Output: %s, Expected Output: %s", output, trueValue)
 				}
 			},
 		},

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -97,6 +97,7 @@ func TestNewDriver(t *testing.T) {
 	fakedriver.Version = driverVersion
 	fakedriver.accountSearchCache = driver.accountSearchCache
 	fakedriver.dataPlaneAPIVolCache = driver.dataPlaneAPIVolCache
+	fakedriver.storageEndpointSuffixCache = driver.storageEndpointSuffixCache
 	fakedriver.azcopySasTokenCache = driver.azcopySasTokenCache
 	fakedriver.volStatsCache = driver.volStatsCache
 	fakedriver.subnetCache = driver.subnetCache

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1436,6 +1436,17 @@ func TestUseDataPlaneAPI(t *testing.T) {
 			},
 		},
 		{
+			name: "volumeID metadata returns oauth without cache",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				volumeID := withOAuthVolumeIDMetadata(fakeVolumeID, "core.windows.net")
+				output := d.useDataPlaneAPI(ctx, volumeID, "")
+				if output != oauth {
+					t.Errorf("Actual Output: %s, Expected Output: %s", output, oauth)
+				}
+			},
+		},
+		{
 			name: "account cache legacy non-empty value returns true",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
@@ -1493,6 +1504,15 @@ func TestResolvedStorageEndpointSuffix(t *testing.T) {
 		output := d.resolvedStorageEndpointSuffix(ctx, fakeVolumeID, fakeAccountName)
 		if output != "core.chinacloudapi.cn" {
 			t.Errorf("Actual Output: %s, Expected Output: %s", output, "core.chinacloudapi.cn")
+		}
+	})
+
+	t.Run("volumeID metadata wins without cache", func(t *testing.T) {
+		d := NewFakeDriver()
+		volumeID := withOAuthVolumeIDMetadata(fakeVolumeID, "core.usgovcloudapi.net")
+		output := d.resolvedStorageEndpointSuffix(ctx, volumeID, fakeAccountName)
+		if output != "core.usgovcloudapi.net" {
+			t.Errorf("Actual Output: %s, Expected Output: %s", output, "core.usgovcloudapi.net")
 		}
 	})
 }

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1439,7 +1439,8 @@ func TestUseDataPlaneAPI(t *testing.T) {
 			name: "volumeID metadata returns oauth without cache",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
-				volumeID := withOAuthVolumeIDMetadata(fakeVolumeID, "core.windows.net")
+				baseVolumeID := fmt.Sprintf(volumeIDTemplate, "rg", "account", "container", "", "ns", "sub")
+				volumeID := withOAuthVolumeIDMetadata(baseVolumeID, "core.windows.net")
 				output := d.useDataPlaneAPI(ctx, volumeID, "")
 				if output != oauth {
 					t.Errorf("Actual Output: %s, Expected Output: %s", output, oauth)
@@ -1509,7 +1510,8 @@ func TestResolvedStorageEndpointSuffix(t *testing.T) {
 
 	t.Run("volumeID metadata wins without cache", func(t *testing.T) {
 		d := NewFakeDriver()
-		volumeID := withOAuthVolumeIDMetadata(fakeVolumeID, "core.usgovcloudapi.net")
+		baseVolumeID := fmt.Sprintf(volumeIDTemplate, "rg", "account", "container", "", "ns", "sub")
+		volumeID := withOAuthVolumeIDMetadata(baseVolumeID, "core.usgovcloudapi.net")
 		output := d.resolvedStorageEndpointSuffix(ctx, volumeID, fakeAccountName)
 		if output != "core.usgovcloudapi.net" {
 			t.Errorf("Actual Output: %s, Expected Output: %s", output, "core.usgovcloudapi.net")

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1472,6 +1472,30 @@ func TestUseDataPlaneAPI(t *testing.T) {
 	}
 }
 
+func TestResolvedStorageEndpointSuffix(t *testing.T) {
+	fakeVolumeID := "unit-test-id"
+	fakeAccountName := "unit-test-account"
+	ctx := context.Background()
+
+	t.Run("volumeID cache wins", func(t *testing.T) {
+		d := NewFakeDriver()
+		d.storageEndpointSuffixCache.Set(fakeVolumeID, "core.usgovcloudapi.net")
+		output := d.resolvedStorageEndpointSuffix(ctx, fakeVolumeID, fakeAccountName)
+		if output != "core.usgovcloudapi.net" {
+			t.Errorf("Actual Output: %s, Expected Output: %s", output, "core.usgovcloudapi.net")
+		}
+	})
+
+	t.Run("account cache fallback", func(t *testing.T) {
+		d := NewFakeDriver()
+		d.storageEndpointSuffixCache.Set(fakeAccountName, "core.chinacloudapi.cn")
+		output := d.resolvedStorageEndpointSuffix(ctx, fakeVolumeID, fakeAccountName)
+		if output != "core.chinacloudapi.cn" {
+			t.Errorf("Actual Output: %s, Expected Output: %s", output, "core.chinacloudapi.cn")
+		}
+	})
+}
+
 func TestTokenizeMountOptionsString(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	azcontainer "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 	azstorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -97,7 +98,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	var storageAccountType, subsID, resourceGroup, location, account, containerName, containerNamePrefix, protocol, customTags, secretName, secretNamespace, pvcNamespace, tagValueDelimiter string
 	var isHnsEnabled, requireInfraEncryption, enableBlobVersioning, createPrivateEndpoint, enableNfsV3, allowSharedKeyAccess *bool
 	var vnetResourceGroup, vnetName, vnetLinkName, publicNetworkAccess, subnetName, accessTier, networkEndpointType, storageEndpointSuffix, fsGroupChangePolicy, srcAccountName, privateDNSZoneResourceGroup string
-	var matchTags, useDataPlaneAPI, getLatestAccountKey bool
+	var matchTags, getLatestAccountKey bool
+	var useDataPlaneAPI string
 	var softDeleteBlobs, softDeleteContainers int32
 	var vnetResourceIDs []string
 	var err error
@@ -230,7 +232,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 				}
 			}
 		case useDataPlaneAPIField:
-			useDataPlaneAPI = strings.EqualFold(v, trueValue)
+			if !strings.EqualFold(v, trueValue) && !strings.EqualFold(v, falseValue) && !strings.EqualFold(v, oauth) {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %s in storage class", useDataPlaneAPIField, v)
+			}
+			useDataPlaneAPI = v
 		case fsGroupChangePolicyField:
 			fsGroupChangePolicy = v
 		case tagValueDelimiterField:
@@ -475,7 +480,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	accountOptions.Name = accountName
-	if len(secrets) == 0 && useDataPlaneAPI {
+	if len(secrets) == 0 && strings.EqualFold(useDataPlaneAPI, trueValue) {
 		if accountKey == "" {
 			if accountName, accountKey, err = d.GetStorageAccesskey(ctx, accountOptions, secrets, secretName, secretNamespace); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to GetStorageAccesskey on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
@@ -490,13 +495,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	// may be pre-existing and not owned by CSI. For auto-generated container names, CSI owns
 	// the lifecycle and should clean up on failure to avoid orphaned containers.
 	shouldCleanupContainer := (containerName == "")
-	if err := d.CreateBlobContainer(ctx, subsID, resourceGroup, accountName, validContainerName, storageEndpointSuffix, secrets); err != nil {
+	if err := d.CreateBlobContainer(ctx, subsID, resourceGroup, accountName, validContainerName, storageEndpointSuffix, secrets, useDataPlaneAPI); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create container(%s) on account(%s) type(%s) rg(%s) location(%s) size(%d), error: %v", validContainerName, accountName, storageAccountType, resourceGroup, location, requestGiB, err)
 	}
 	if volContentSource != nil {
 		accountSASToken, authAzcopyEnv, err := d.getAzcopyAuth(ctx, accountName, accountKey, storageEndpointSuffix, accountOptions, secrets, secretName, secretNamespace, false)
 		if err != nil {
-			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, "getAzcopyAuth failure")
+			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, useDataPlaneAPI, "getAzcopyAuth failure")
 			return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
 		}
 		copyErr := d.copyVolume(ctx, req, accountName, accountSASToken, authAzcopyEnv, validContainerName, secretNamespace, accountOptions, storageEndpointSuffix)
@@ -507,13 +512,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			// variable would leave the outer authAzcopyEnv pinned to the first auth attempt.
 			accountSASToken, authAzcopyEnv, err = d.getAzcopyAuth(ctx, accountName, accountKey, storageEndpointSuffix, accountOptions, secrets, secretName, secretNamespace, true)
 			if err != nil {
-				d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, "fallback getAzcopyAuth failure")
+				d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, useDataPlaneAPI, "fallback getAzcopyAuth failure")
 				return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
 			}
 			copyErr = d.copyVolume(ctx, req, accountName, accountSASToken, authAzcopyEnv, validContainerName, secretNamespace, accountOptions, storageEndpointSuffix)
 		}
 		if copyErr != nil {
-			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, fmt.Sprintf("copyVolume(%s) failure", validContainerName))
+			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, useDataPlaneAPI, fmt.Sprintf("copyVolume(%s) failure", validContainerName))
 			return nil, copyErr
 		}
 	}
@@ -543,9 +548,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	volumeID = fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, validContainerName, uuid, secretNamespace, subsID)
 	klog.V(2).Infof("create container %s on storage account %s successfully", validContainerName, accountName)
 
-	if useDataPlaneAPI {
-		d.dataPlaneAPIVolCache.Set(volumeID, "")
-		d.dataPlaneAPIVolCache.Set(accountName, "")
+	if strings.EqualFold(useDataPlaneAPI, trueValue) || strings.EqualFold(useDataPlaneAPI, oauth) {
+		d.dataPlaneAPIVolCache.Set(volumeID, useDataPlaneAPI)
+		d.dataPlaneAPIVolCache.Set(accountName, useDataPlaneAPI)
 	}
 
 	isOperationSucceeded = true
@@ -584,7 +589,7 @@ func isAzcopyJobActiveOrCompleted(state util.AzcopyJobState) bool {
 // It checks for a running or completed azcopy job first — if a job is still in progress or
 // has just completed, the container is preserved so retries can resume rather than starting
 // from zero, and to avoid racing with a copy that finished right as CreateVolume returned.
-func (d *Driver) cleanupContainerOnFailure(shouldCleanupContainer bool, subsID, resourceGroup, accountName, containerName string, secrets map[string]string, authAzcopyEnv []string, reason string) {
+func (d *Driver) cleanupContainerOnFailure(shouldCleanupContainer bool, subsID, resourceGroup, accountName, containerName string, secrets map[string]string, authAzcopyEnv []string, useDataPlaneAPI string, reason string) {
 	if !shouldCleanupContainer {
 		return
 	}
@@ -612,7 +617,7 @@ func (d *Driver) cleanupContainerOnFailure(shouldCleanupContainer bool, subsID, 
 	// context from the original CreateVolume request (e.g., after azcopy timeout).
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	if cleanupErr := d.DeleteBlobContainer(cleanupCtx, subsID, resourceGroup, accountName, containerName, secrets); cleanupErr != nil {
+	if cleanupErr := d.DeleteBlobContainer(cleanupCtx, subsID, resourceGroup, accountName, containerName, secrets, useDataPlaneAPI); cleanupErr != nil {
 		klog.Warningf("failed to clean up container(%s) on account(%s) rg(%s) after %s: %v", containerName, accountName, resourceGroup, reason, cleanupErr)
 	}
 }
@@ -641,7 +646,8 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 	}
 
 	secrets := req.GetSecrets()
-	if len(secrets) == 0 && d.useDataPlaneAPI(ctx, volumeID, accountName) {
+	useDataPlaneAPI := d.useDataPlaneAPI(ctx, volumeID, accountName)
+	if len(secrets) == 0 && strings.EqualFold(useDataPlaneAPI, trueValue) {
 		_, accountName, accountKey, _, _, err := d.GetAuthEnv(ctx, volumeID, "", nil, secrets)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "GetAuthEnv(%s) failed with %v", volumeID, err)
@@ -661,7 +667,7 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		resourceGroupName = d.cloud.ResourceGroup
 	}
 	klog.V(2).Infof("deleting container(%s) rg(%s) account(%s) volumeID(%s)", containerName, resourceGroupName, accountName, volumeID)
-	if err := d.DeleteBlobContainer(ctx, subsID, resourceGroupName, accountName, containerName, secrets); err != nil {
+	if err := d.DeleteBlobContainer(ctx, subsID, resourceGroupName, accountName, containerName, secrets, useDataPlaneAPI); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete container(%s) under rg(%s) account(%s) volumeID(%s), error: %v", containerName, resourceGroupName, accountName, volumeID, err)
 	}
 
@@ -820,7 +826,7 @@ func (d *Driver) ControllerExpandVolume(_ context.Context, req *csi.ControllerEx
 }
 
 // CreateBlobContainer creates a blob container
-func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName, storageEndpointSuffix string, secrets map[string]string) error {
+func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName, storageEndpointSuffix string, secrets map[string]string, useDataPlaneAPI string) error {
 	if containerName == "" {
 		return fmt.Errorf("containerName is empty")
 	}
@@ -838,6 +844,19 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 			}
 			container.Metadata = map[string]string{createdByMetadata: d.Name}
 			_, err = container.CreateIfNotExists(&azstorage.CreateContainerOptions{Access: azstorage.ContainerAccessTypePrivate})
+		} else if d.cloud != nil && d.cloud.AuthProvider != nil && strings.EqualFold(useDataPlaneAPI, oauth) {
+			containerURL := fmt.Sprintf("https://%s.blob.%s/%s", accountName, storageEndpointSuffix, containerName)
+			client, clientErr := azcontainer.NewClient(containerURL, d.cloud.AuthProvider.GetAzIdentity(), nil)
+			if clientErr != nil {
+				return true, clientErr
+			}
+			_, err = client.Create(ctx, &azcontainer.CreateOptions{
+				Metadata: map[string]*string{createdByMetadata: to.Ptr(d.Name)},
+			})
+			if err != nil && strings.Contains(err.Error(), "ContainerAlreadyExists") {
+				klog.V(2).Infof("container(%s) on account(%s) already exists", containerName, accountName)
+				err = nil
+			}
 		} else {
 			blobContainer := armstorage.BlobContainer{
 				ContainerProperties: &armstorage.ContainerProperties{
@@ -866,7 +885,7 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 }
 
 // DeleteBlobContainer deletes a blob container
-func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName string, secrets map[string]string) error {
+func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName string, secrets map[string]string, useDataPlaneAPI string) error {
 	if containerName == "" {
 		return fmt.Errorf("containerName is empty")
 	}
@@ -883,6 +902,17 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 				return true, getErr
 			}
 			_, err = container.DeleteIfExists(nil)
+		} else if d.cloud != nil && d.cloud.AuthProvider != nil && strings.EqualFold(useDataPlaneAPI, oauth) {
+			containerURL := fmt.Sprintf("https://%s.blob.%s/%s", accountName, d.getStorageEndPointSuffix(), containerName)
+			client, clientErr := azcontainer.NewClient(containerURL, d.cloud.AuthProvider.GetAzIdentity(), nil)
+			if clientErr != nil {
+				return true, clientErr
+			}
+			_, err = client.Delete(ctx, nil)
+			if err != nil && (strings.Contains(err.Error(), statusCodeNotFound) || strings.Contains(err.Error(), httpCodeNotFound)) {
+				klog.V(2).Infof("container(%s) on account(%s) not found, return as success", containerName, accountName)
+				err = nil
+			}
 		} else {
 			var blobClient blobcontainerclient.Interface
 			blobClient, err = d.clientFactory.GetBlobContainerClientForSub(subsID)
@@ -1048,7 +1078,7 @@ func (d *Driver) authorizeAzcopyWithIdentity() ([]string, error) {
 func (d *Driver) getAzcopyAuth(ctx context.Context, accountName, accountKey, storageEndpointSuffix string, accountOptions *storage.AccountOptions, secrets map[string]string, secretName, secretNamespace string, useSasToken bool) (string, []string, error) {
 	var authAzcopyEnv []string
 	var err error
-	if !useSasToken && !d.useDataPlaneAPI(ctx, "", accountName) && len(secrets) == 0 && len(secretName) == 0 {
+	if !useSasToken && d.useDataPlaneAPI(ctx, "", accountName) == "" && len(secrets) == 0 && len(secretName) == 0 {
 		// search in cache first
 		if cache, err := d.azcopySasTokenCache.Get(ctx, accountName, azcache.CacheReadTypeDefault); err == nil && cache != nil {
 			klog.V(2).Infof("use sas token for account(%s) since this account is found in azcopySasTokenCache", accountName)

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -501,7 +501,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	if volContentSource != nil {
 		accountSASToken, authAzcopyEnv, err := d.getAzcopyAuth(ctx, accountName, accountKey, storageEndpointSuffix, accountOptions, secrets, secretName, secretNamespace, false)
 		if err != nil {
-			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, useDataPlaneAPI, "getAzcopyAuth failure")
+			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, storageEndpointSuffix, secrets, authAzcopyEnv, useDataPlaneAPI, "getAzcopyAuth failure")
 			return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
 		}
 		copyErr := d.copyVolume(ctx, req, accountName, accountSASToken, authAzcopyEnv, validContainerName, secretNamespace, accountOptions, storageEndpointSuffix)
@@ -512,13 +512,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			// variable would leave the outer authAzcopyEnv pinned to the first auth attempt.
 			accountSASToken, authAzcopyEnv, err = d.getAzcopyAuth(ctx, accountName, accountKey, storageEndpointSuffix, accountOptions, secrets, secretName, secretNamespace, true)
 			if err != nil {
-				d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, useDataPlaneAPI, "fallback getAzcopyAuth failure")
+				d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, storageEndpointSuffix, secrets, authAzcopyEnv, useDataPlaneAPI, "fallback getAzcopyAuth failure")
 				return nil, status.Errorf(codes.Internal, "failed to getAzcopyAuth on account(%s) rg(%s), error: %v", accountOptions.Name, accountOptions.ResourceGroup, err)
 			}
 			copyErr = d.copyVolume(ctx, req, accountName, accountSASToken, authAzcopyEnv, validContainerName, secretNamespace, accountOptions, storageEndpointSuffix)
 		}
 		if copyErr != nil {
-			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, secrets, authAzcopyEnv, useDataPlaneAPI, fmt.Sprintf("copyVolume(%s) failure", validContainerName))
+			d.cleanupContainerOnFailure(shouldCleanupContainer, subsID, resourceGroup, accountName, validContainerName, storageEndpointSuffix, secrets, authAzcopyEnv, useDataPlaneAPI, fmt.Sprintf("copyVolume(%s) failure", validContainerName))
 			return nil, copyErr
 		}
 	}
@@ -552,6 +552,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		d.dataPlaneAPIVolCache.Set(volumeID, useDataPlaneAPI)
 		d.dataPlaneAPIVolCache.Set(accountName, useDataPlaneAPI)
 	}
+	d.storageEndpointSuffixCache.Set(volumeID, storageEndpointSuffix)
+	d.storageEndpointSuffixCache.Set(accountName, storageEndpointSuffix)
 
 	isOperationSucceeded = true
 	// reset secretNamespace field in VolumeContext
@@ -589,7 +591,7 @@ func isAzcopyJobActiveOrCompleted(state util.AzcopyJobState) bool {
 // It checks for a running or completed azcopy job first — if a job is still in progress or
 // has just completed, the container is preserved so retries can resume rather than starting
 // from zero, and to avoid racing with a copy that finished right as CreateVolume returned.
-func (d *Driver) cleanupContainerOnFailure(shouldCleanupContainer bool, subsID, resourceGroup, accountName, containerName string, secrets map[string]string, authAzcopyEnv []string, useDataPlaneAPI string, reason string) {
+func (d *Driver) cleanupContainerOnFailure(shouldCleanupContainer bool, subsID, resourceGroup, accountName, containerName, storageEndpointSuffix string, secrets map[string]string, authAzcopyEnv []string, useDataPlaneAPI string, reason string) {
 	if !shouldCleanupContainer {
 		return
 	}
@@ -617,7 +619,7 @@ func (d *Driver) cleanupContainerOnFailure(shouldCleanupContainer bool, subsID, 
 	// context from the original CreateVolume request (e.g., after azcopy timeout).
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	if cleanupErr := d.DeleteBlobContainer(cleanupCtx, subsID, resourceGroup, accountName, containerName, secrets, useDataPlaneAPI); cleanupErr != nil {
+	if cleanupErr := d.DeleteBlobContainer(cleanupCtx, subsID, resourceGroup, accountName, containerName, storageEndpointSuffix, secrets, useDataPlaneAPI); cleanupErr != nil {
 		klog.Warningf("failed to clean up container(%s) on account(%s) rg(%s) after %s: %v", containerName, accountName, resourceGroup, reason, cleanupErr)
 	}
 }
@@ -667,7 +669,8 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		resourceGroupName = d.cloud.ResourceGroup
 	}
 	klog.V(2).Infof("deleting container(%s) rg(%s) account(%s) volumeID(%s)", containerName, resourceGroupName, accountName, volumeID)
-	if err := d.DeleteBlobContainer(ctx, subsID, resourceGroupName, accountName, containerName, secrets, useDataPlaneAPI); err != nil {
+	storageEndpointSuffix := d.resolvedStorageEndpointSuffix(ctx, volumeID, accountName)
+	if err := d.DeleteBlobContainer(ctx, subsID, resourceGroupName, accountName, containerName, storageEndpointSuffix, secrets, useDataPlaneAPI); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete container(%s) under rg(%s) account(%s) volumeID(%s), error: %v", containerName, resourceGroupName, accountName, volumeID, err)
 	}
 
@@ -844,7 +847,10 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 			}
 			container.Metadata = map[string]string{createdByMetadata: d.Name}
 			_, err = container.CreateIfNotExists(&azstorage.CreateContainerOptions{Access: azstorage.ContainerAccessTypePrivate})
-		} else if d.cloud != nil && d.cloud.AuthProvider != nil && strings.EqualFold(useDataPlaneAPI, oauth) {
+		} else if strings.EqualFold(useDataPlaneAPI, oauth) {
+			if d.cloud == nil || d.cloud.AuthProvider == nil {
+				return true, fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth)
+			}
 			containerURL := fmt.Sprintf("https://%s.blob.%s/%s", accountName, storageEndpointSuffix, containerName)
 			client, clientErr := azcontainer.NewClient(containerURL, d.cloud.AuthProvider.GetAzIdentity(), nil)
 			if clientErr != nil {
@@ -888,7 +894,7 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 }
 
 // DeleteBlobContainer deletes a blob container
-func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName string, secrets map[string]string, useDataPlaneAPI string) error {
+func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName, storageEndpointSuffix string, secrets map[string]string, useDataPlaneAPI string) error {
 	if containerName == "" {
 		return fmt.Errorf("containerName is empty")
 	}
@@ -900,13 +906,16 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 	err := wait.ExponentialBackoffWithContext(ctx, getBackOff(d.cloud.Config), func(ctx context.Context) (bool, error) {
 		var err error
 		if len(secrets) > 0 {
-			container, getErr := getContainerReference(containerName, secrets, d.getStorageEndPointSuffix())
+			container, getErr := getContainerReference(containerName, secrets, storageEndpointSuffix)
 			if getErr != nil {
 				return true, getErr
 			}
 			_, err = container.DeleteIfExists(nil)
-		} else if d.cloud != nil && d.cloud.AuthProvider != nil && strings.EqualFold(useDataPlaneAPI, oauth) {
-			containerURL := fmt.Sprintf("https://%s.blob.%s/%s", accountName, d.getStorageEndPointSuffix(), containerName)
+		} else if strings.EqualFold(useDataPlaneAPI, oauth) {
+			if d.cloud == nil || d.cloud.AuthProvider == nil {
+				return true, fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth)
+			}
+			containerURL := fmt.Sprintf("https://%s.blob.%s/%s", accountName, storageEndpointSuffix, containerName)
 			client, clientErr := azcontainer.NewClient(containerURL, d.cloud.AuthProvider.GetAzIdentity(), nil)
 			if clientErr != nil {
 				return true, clientErr

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -1138,7 +1138,7 @@ func (d *Driver) authorizeAzcopyWithIdentity() ([]string, error) {
 func (d *Driver) getAzcopyAuth(ctx context.Context, accountName, accountKey, storageEndpointSuffix string, accountOptions *storage.AccountOptions, secrets map[string]string, secretName, secretNamespace string, useSasToken bool) (string, []string, error) {
 	var authAzcopyEnv []string
 	var err error
-	if !useSasToken && d.useDataPlaneAPI(ctx, "", accountName) == "" && len(secrets) == 0 && len(secretName) == 0 {
+	if !useSasToken && !strings.EqualFold(d.useDataPlaneAPI(ctx, "", accountName), trueValue) && len(secrets) == 0 && len(secretName) == 0 {
 		// search in cache first
 		if cache, err := d.azcopySasTokenCache.Get(ctx, accountName, azcache.CacheReadTypeDefault); err == nil && cache != nil {
 			klog.V(2).Infof("use sas token for account(%s) since this account is found in azcopySasTokenCache", accountName)

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -851,6 +851,9 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 			container.Metadata = map[string]string{createdByMetadata: d.Name}
 			_, err = container.CreateIfNotExists(&azstorage.CreateContainerOptions{Access: azstorage.ContainerAccessTypePrivate})
 		} else if strings.EqualFold(useDataPlaneAPI, oauth) {
+			if err := d.validateOAuthStorageEndpointSuffix(storageEndpointSuffix); err != nil {
+				return true, err
+			}
 			if d.cloud == nil || d.cloud.AuthProvider == nil {
 				return true, fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth)
 			}
@@ -896,6 +899,18 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 	return err
 }
 
+func (d *Driver) validateOAuthStorageEndpointSuffix(storageEndpointSuffix string) error {
+	expected := d.getStorageEndPointSuffix()
+	actual := strings.TrimSpace(storageEndpointSuffix)
+	if actual == "" {
+		actual = expected
+	}
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("storageEndpointSuffix %q is not allowed with useDataPlaneAPI=%q, expected %q", actual, oauth, expected)
+	}
+	return nil
+}
+
 // isContainerNotFoundErr returns true when the delete target is already gone.
 func isContainerNotFoundErr(err error) bool {
 	if err == nil {
@@ -937,6 +952,9 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 			}
 			_, err = container.DeleteIfExists(nil)
 		} else if strings.EqualFold(useDataPlaneAPI, oauth) {
+			if err := d.validateOAuthStorageEndpointSuffix(storageEndpointSuffix); err != nil {
+				return true, err
+			}
 			if d.cloud == nil || d.cloud.AuthProvider == nil {
 				return true, fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth)
 			}

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -864,6 +864,9 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 					Metadata:     map[string]*string{createdByMetadata: to.Ptr(d.Name)},
 				},
 			}
+			if d.clientFactory == nil {
+				return true, fmt.Errorf("blob container client factory is nil")
+			}
 			var blobClient blobcontainerclient.Interface
 			blobClient, err = d.clientFactory.GetBlobContainerClientForSub(subsID)
 			if err != nil {
@@ -914,6 +917,9 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 				err = nil
 			}
 		} else {
+			if d.clientFactory == nil {
+				return true, fmt.Errorf("blob container client factory is nil")
+			}
 			var blobClient blobcontainerclient.Interface
 			blobClient, err = d.clientFactory.GetBlobContainerClientForSub(subsID)
 			if err != nil {

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -19,7 +19,9 @@ package blob
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -30,6 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -893,7 +896,29 @@ func (d *Driver) CreateBlobContainer(ctx context.Context, subsID, resourceGroupN
 	return err
 }
 
-// DeleteBlobContainer deletes a blob container
+// isContainerNotFoundErr returns true when the delete target is already gone.
+func isContainerNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) {
+		if responseErr.StatusCode == http.StatusNotFound {
+			return true
+		}
+		if strings.EqualFold(responseErr.ErrorCode, "ContainerNotFound") {
+			return true
+		}
+	}
+
+	return strings.Contains(err.Error(), statusCodeNotFound) ||
+		strings.Contains(err.Error(), httpCodeNotFound) ||
+		strings.Contains(err.Error(), "RESPONSE 404") ||
+		strings.Contains(err.Error(), "ContainerNotFound")
+}
+
+// DeleteBlobContainer deletes a blob container.
 func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupName, accountName, containerName, storageEndpointSuffix string, secrets map[string]string, useDataPlaneAPI string) error {
 	if containerName == "" {
 		return fmt.Errorf("containerName is empty")
@@ -921,7 +946,7 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 				return true, clientErr
 			}
 			_, err = client.Delete(ctx, nil)
-			if err != nil && (strings.Contains(err.Error(), statusCodeNotFound) || strings.Contains(err.Error(), httpCodeNotFound)) {
+			if isContainerNotFoundErr(err) {
 				klog.V(2).Infof("container(%s) on account(%s) not found, return as success", containerName, accountName)
 				err = nil
 			}
@@ -939,8 +964,7 @@ func (d *Driver) DeleteBlobContainer(ctx context.Context, subsID, resourceGroupN
 		if err != nil {
 			if strings.Contains(err.Error(), containerBeingDeletedDataplaneAPIError) ||
 				strings.Contains(err.Error(), containerBeingDeletedManagementAPIError) ||
-				strings.Contains(err.Error(), statusCodeNotFound) ||
-				strings.Contains(err.Error(), httpCodeNotFound) {
+				isContainerNotFoundErr(err) {
 				klog.Warningf("delete container(%s) on account(%s) failed with error(%v), return as success", containerName, accountName, err)
 				return true, nil
 			}

--- a/pkg/blob/controllerserver.go
+++ b/pkg/blob/controllerserver.go
@@ -549,6 +549,9 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		uuid = volName
 	}
 	volumeID = fmt.Sprintf(volumeIDTemplate, resourceGroup, accountName, validContainerName, uuid, secretNamespace, subsID)
+	if strings.EqualFold(useDataPlaneAPI, oauth) {
+		volumeID = withOAuthVolumeIDMetadata(volumeID, storageEndpointSuffix)
+	}
 	klog.V(2).Infof("create container %s on storage account %s successfully", validContainerName, accountName)
 
 	if strings.EqualFold(useDataPlaneAPI, trueValue) || strings.EqualFold(useDataPlaneAPI, oauth) {

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
@@ -1608,6 +1609,54 @@ func TestCreateBlobContainer(t *testing.T) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}
 		controller.Finish()
+	}
+}
+
+func TestIsContainerNotFoundErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "response error status 404",
+			err: &azcore.ResponseError{StatusCode: 404},
+			want: true,
+		},
+		{
+			name: "response error code container not found",
+			err: &azcore.ResponseError{ErrorCode: "ContainerNotFound"},
+			want: true,
+		},
+		{
+			name: "wrapped response error",
+			err: fmt.Errorf("wrapped: %w", &azcore.ResponseError{StatusCode: 404}),
+			want: true,
+		},
+		{
+			name: "legacy response string",
+			err: fmt.Errorf("DELETE https://acct.blob.core.windows.net/c\nRESPONSE 404: 404 The specified container does not exist.\nERROR CODE: ContainerNotFound"),
+			want: true,
+		},
+		{
+			name: "other error",
+			err: fmt.Errorf("boom"),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isContainerNotFoundErr(test.err)
+			if got != test.want {
+				t.Fatalf("isContainerNotFoundErr(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
 	}
 }
 

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -2373,6 +2373,36 @@ func TestGetAzcopyAuth(t *testing.T) {
 			},
 		},
 		{
+			name: "oauth account uses identity auth instead of sas",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.cloud = &storage.AccountRepo{
+					Config: config.Config{
+						AzureClientConfig: config.AzureClientConfig{
+							AzureAuthConfig: azclient.AzureAuthConfig{
+								UseManagedIdentityExtension: true,
+								UserAssignedIdentityID:      "test-client-id",
+							},
+						},
+					},
+				}
+				d.dataPlaneAPIVolCache.Set("accountName", oauth)
+				accountSASToken, authAzcopyEnv, err := d.getAzcopyAuth(context.Background(), "accountName", "", defaultStorageEndPointSuffix, &storage.AccountOptions{}, nil, "", "", false)
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if accountSASToken != "" {
+					t.Fatalf("Expected empty SAS token for oauth account, got: %s", accountSASToken)
+				}
+				if !reflect.DeepEqual(authAzcopyEnv, []string{
+					fmt.Sprintf("%s=%s", azcopyAutoLoginType, MSI),
+					fmt.Sprintf("%s=%s", azcopyMSIClientID, "test-client-id"),
+				}) {
+					t.Fatalf("Unexpected authAzcopyEnv: %v", authAzcopyEnv)
+				}
+			},
+		},
+		{
 			name: "fall back to generate SAS token failed for illegal account key",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -1516,16 +1516,17 @@ func TestControllerExpandVolume(t *testing.T) {
 
 func TestCreateBlobContainer(t *testing.T) {
 	tests := []struct {
-		desc            string
-		subsID          string
-		rg              string
-		accountName     string
-		containerName   string
-		secrets         map[string]string
-		customErrStr    string
-		clientErr       errType
-		useDataPlaneAPI string
-		expectedErr     error
+		desc                  string
+		subsID                string
+		rg                    string
+		accountName           string
+		containerName         string
+		storageEndpointSuffix string
+		secrets               map[string]string
+		customErrStr          string
+		clientErr             errType
+		useDataPlaneAPI       string
+		expectedErr           error
 	}{
 		{
 			desc:        "containerName is empty",
@@ -1572,6 +1573,15 @@ func TestCreateBlobContainer(t *testing.T) {
 			expectedErr:   fmt.Errorf("foobar"),
 		},
 		{
+			desc:                  "oauth rejects untrusted storage endpoint suffix",
+			containerName:         "containerName",
+			accountName:           "accountName",
+			storageEndpointSuffix: "evil.example",
+			secrets:               map[string]string{},
+			useDataPlaneAPI:       oauth,
+			expectedErr:           fmt.Errorf("storageEndpointSuffix %q is not allowed with useDataPlaneAPI=%q, expected %q", "evil.example", oauth, defaultStorageEndPointSuffix),
+		},
+		{
 			desc:            "oauth requires auth provider",
 			containerName:   "containerName",
 			accountName:     "accountName",
@@ -1604,11 +1614,60 @@ func TestCreateBlobContainer(t *testing.T) {
 				}
 				return nil, nil
 			}).AnyTimes()
-		err := d.CreateBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets, test.useDataPlaneAPI)
+		storageEndpointSuffix := test.storageEndpointSuffix
+		if storageEndpointSuffix == "" {
+			storageEndpointSuffix = defaultStorageEndPointSuffix
+		}
+		err := d.CreateBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, storageEndpointSuffix, test.secrets, test.useDataPlaneAPI)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}
 		controller.Finish()
+	}
+}
+
+func TestValidateOAuthStorageEndpointSuffix(t *testing.T) {
+	tests := []struct {
+		name                  string
+		driverSuffix          string
+		storageEndpointSuffix string
+		wantErr               error
+	}{
+		{
+			name:                  "empty suffix uses default cloud suffix",
+			storageEndpointSuffix: "",
+			wantErr:               nil,
+		},
+		{
+			name:                  "matching default suffix",
+			storageEndpointSuffix: defaultStorageEndPointSuffix,
+			wantErr:               nil,
+		},
+		{
+			name:                  "matching configured environment suffix",
+			driverSuffix:          "core.usgovcloudapi.net",
+			storageEndpointSuffix: "core.usgovcloudapi.net",
+			wantErr:               nil,
+		},
+		{
+			name:                  "rejects untrusted suffix",
+			storageEndpointSuffix: "evil.example",
+			wantErr:               fmt.Errorf("storageEndpointSuffix %q is not allowed with useDataPlaneAPI=%q, expected %q", "evil.example", oauth, defaultStorageEndPointSuffix),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := NewFakeDriver()
+			d.cloud = &storage.AccountRepo{}
+			if test.driverSuffix != "" {
+				d.cloud.Environment = &azclient.Environment{StorageEndpointSuffix: test.driverSuffix}
+			}
+			err := d.validateOAuthStorageEndpointSuffix(test.storageEndpointSuffix)
+			if !reflect.DeepEqual(err, test.wantErr) {
+				t.Fatalf("validateOAuthStorageEndpointSuffix(%q) = %v, want %v", test.storageEndpointSuffix, err, test.wantErr)
+			}
+		})
 	}
 }
 
@@ -1672,16 +1731,17 @@ func TestIsContainerNotFoundErr(t *testing.T) {
 
 func TestDeleteBlobContainer(t *testing.T) {
 	tests := []struct {
-		desc            string
-		subsID          string
-		rg              string
-		accountName     string
-		containerName   string
-		secrets         map[string]string
-		clientErr       errType
-		customErrStr    string
-		useDataPlaneAPI string
-		expectedErr     error
+		desc                  string
+		subsID                string
+		rg                    string
+		accountName           string
+		containerName         string
+		storageEndpointSuffix string
+		secrets               map[string]string
+		clientErr             errType
+		customErrStr          string
+		useDataPlaneAPI       string
+		expectedErr           error
 	}{
 		{
 			desc:        "containerName is empty",
@@ -1729,6 +1789,15 @@ func TestDeleteBlobContainer(t *testing.T) {
 				fmt.Errorf("foobar")),
 		},
 		{
+			desc:                  "oauth rejects untrusted storage endpoint suffix",
+			containerName:         "containerName",
+			accountName:           "accountName",
+			storageEndpointSuffix: "evil.example",
+			secrets:               map[string]string{},
+			useDataPlaneAPI:       oauth,
+			expectedErr:           fmt.Errorf("storageEndpointSuffix %q is not allowed with useDataPlaneAPI=%q, expected %q", "evil.example", oauth, defaultStorageEndPointSuffix),
+		},
+		{
 			desc:            "oauth requires auth provider",
 			containerName:   "containerName",
 			accountName:     "accountName",
@@ -1761,7 +1830,11 @@ func TestDeleteBlobContainer(t *testing.T) {
 				}
 				return nil
 			}).AnyTimes()
-		err := d.DeleteBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets, test.useDataPlaneAPI)
+		storageEndpointSuffix := test.storageEndpointSuffix
+		if storageEndpointSuffix == "" {
+			storageEndpointSuffix = defaultStorageEndPointSuffix
+		}
+		err := d.DeleteBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, storageEndpointSuffix, test.secrets, test.useDataPlaneAPI)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -1655,7 +1655,7 @@ func TestIsContainerNotFoundErr(t *testing.T) {
 		},
 		{
 			name: "other error",
-			err: fmt.Errorf("boom"),
+			err:  fmt.Errorf("boom"),
 			want: false,
 		},
 	}

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -1515,15 +1515,16 @@ func TestControllerExpandVolume(t *testing.T) {
 
 func TestCreateBlobContainer(t *testing.T) {
 	tests := []struct {
-		desc          string
-		subsID        string
-		rg            string
-		accountName   string
-		containerName string
-		secrets       map[string]string
-		customErrStr  string
-		clientErr     errType
-		expectedErr   error
+		desc            string
+		subsID          string
+		rg              string
+		accountName     string
+		containerName   string
+		secrets         map[string]string
+		customErrStr    string
+		clientErr       errType
+		useDataPlaneAPI string
+		expectedErr     error
 	}{
 		{
 			desc:        "containerName is empty",
@@ -1569,6 +1570,14 @@ func TestCreateBlobContainer(t *testing.T) {
 			customErrStr:  "foobar",
 			expectedErr:   fmt.Errorf("foobar"),
 		},
+		{
+			desc:            "oauth requires auth provider",
+			containerName:   "containerName",
+			accountName:     "accountName",
+			secrets:         map[string]string{},
+			useDataPlaneAPI: oauth,
+			expectedErr:     fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth),
+		},
 	}
 
 	d := NewFakeDriver()
@@ -1594,7 +1603,7 @@ func TestCreateBlobContainer(t *testing.T) {
 				}
 				return nil, nil
 			}).AnyTimes()
-		err := d.CreateBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets, "")
+		err := d.CreateBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets, test.useDataPlaneAPI)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}
@@ -1604,15 +1613,16 @@ func TestCreateBlobContainer(t *testing.T) {
 
 func TestDeleteBlobContainer(t *testing.T) {
 	tests := []struct {
-		desc          string
-		subsID        string
-		rg            string
-		accountName   string
-		containerName string
-		secrets       map[string]string
-		clientErr     errType
-		customErrStr  string
-		expectedErr   error
+		desc            string
+		subsID          string
+		rg              string
+		accountName     string
+		containerName   string
+		secrets         map[string]string
+		clientErr       errType
+		customErrStr    string
+		useDataPlaneAPI string
+		expectedErr     error
 	}{
 		{
 			desc:        "containerName is empty",
@@ -1659,6 +1669,15 @@ func TestDeleteBlobContainer(t *testing.T) {
 			expectedErr: fmt.Errorf("failed to delete container(%s) on account(%s), error: %w", "containerName", "",
 				fmt.Errorf("foobar")),
 		},
+		{
+			desc:            "oauth requires auth provider",
+			containerName:   "containerName",
+			accountName:     "accountName",
+			secrets:         map[string]string{},
+			useDataPlaneAPI: oauth,
+			expectedErr: fmt.Errorf("failed to delete container(%s) on account(%s), error: %w", "containerName", "accountName",
+				fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth)),
+		},
 	}
 
 	d := NewFakeDriver()
@@ -1684,7 +1703,7 @@ func TestDeleteBlobContainer(t *testing.T) {
 				}
 				return nil
 			}).AnyTimes()
-		err := d.DeleteBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, test.secrets, "")
+		err := d.DeleteBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets, test.useDataPlaneAPI)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}
@@ -2478,7 +2497,7 @@ func TestCleanupContainerOnFailure(t *testing.T) {
 				Times(expectedCalls)
 
 			// Act. Must not panic even when the delete errors out (best-effort).
-			d.cleanupContainerOnFailure(test.shouldCleanup, "subsID", "rg", testAccount, testContainer, map[string]string{}, []string{}, "", "unit-test")
+			d.cleanupContainerOnFailure(test.shouldCleanup, "subsID", "rg", testAccount, testContainer, "core.windows.net", map[string]string{}, []string{}, "", "unit-test")
 
 			if deleteCalls != expectedCalls {
 				t.Errorf("DeleteContainer call count = %d, expected %d", deleteCalls, expectedCalls)

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -1646,7 +1646,11 @@ func TestIsContainerNotFoundErr(t *testing.T) {
 		},
 		{
 			name: "legacy response string",
-			err: fmt.Errorf("DELETE https://acct.blob.core.windows.net/c\nRESPONSE 404: 404 The specified container does not exist.\nERROR CODE: ContainerNotFound"),
+			err: fmt.Errorf(
+				"DELETE https://acct.blob.core.windows.net/c\n" +
+					"RESPONSE 404: 404 The specified container does not exist.\n" +
+					"ERROR CODE: ContainerNotFound",
+			),
 			want: true,
 		},
 		{

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -1625,17 +1625,23 @@ func TestIsContainerNotFoundErr(t *testing.T) {
 		},
 		{
 			name: "response error status 404",
-			err: &azcore.ResponseError{StatusCode: 404},
+			err: &azcore.ResponseError{
+				StatusCode: 404,
+			},
 			want: true,
 		},
 		{
 			name: "response error code container not found",
-			err: &azcore.ResponseError{ErrorCode: "ContainerNotFound"},
+			err: &azcore.ResponseError{
+				ErrorCode: "ContainerNotFound",
+			},
 			want: true,
 		},
 		{
 			name: "wrapped response error",
-			err: fmt.Errorf("wrapped: %w", &azcore.ResponseError{StatusCode: 404}),
+			err: fmt.Errorf("wrapped: %w", &azcore.ResponseError{
+				StatusCode: 404,
+			}),
 			want: true,
 		},
 		{

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -223,6 +223,52 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid useDataPlaneAPI value",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.cloud = &storage.AccountRepo{}
+				mp := map[string]string{
+					useDataPlaneAPIField: "bogus",
+				}
+				req := &csi.CreateVolumeRequest{
+					Name:               "unit-test",
+					VolumeCapabilities: stdVolumeCapabilities,
+					Parameters:         mp,
+				}
+				d.Cap = []*csi.ControllerServiceCapability{
+					controllerServiceCapability,
+				}
+				_, err := d.CreateVolume(context.Background(), req)
+				expectedErr := status.Errorf(codes.InvalidArgument, "invalid %s: %s in storage class", useDataPlaneAPIField, "bogus")
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
+		{
+			name: "valid useDataPlaneAPI oauth value",
+			testFunc: func(t *testing.T) {
+				d := NewFakeDriver()
+				d.cloud = &storage.AccountRepo{}
+				mp := map[string]string{
+					useDataPlaneAPIField: "oauth",
+				}
+				req := &csi.CreateVolumeRequest{
+					Name:               "unit-test",
+					VolumeCapabilities: stdVolumeCapabilities,
+					Parameters:         mp,
+				}
+				d.Cap = []*csi.ControllerServiceCapability{
+					controllerServiceCapability,
+				}
+				_, err := d.CreateVolume(context.Background(), req)
+				// Should not return InvalidArgument for 'oauth' - it should proceed past parameter parsing
+				if err != nil && strings.Contains(err.Error(), "invalid "+useDataPlaneAPIField) {
+					t.Errorf("useDataPlaneAPI: oauth should be valid, got error: %v", err)
+				}
+			},
+		},
+		{
 			name: "storageAccount and matchTags conflict",
 			testFunc: func(t *testing.T) {
 				d := NewFakeDriver()
@@ -1548,7 +1594,7 @@ func TestCreateBlobContainer(t *testing.T) {
 				}
 				return nil, nil
 			}).AnyTimes()
-		err := d.CreateBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets)
+		err := d.CreateBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, "core.windows.net", test.secrets, "")
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}
@@ -1638,7 +1684,7 @@ func TestDeleteBlobContainer(t *testing.T) {
 				}
 				return nil
 			}).AnyTimes()
-		err := d.DeleteBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, test.secrets)
+		err := d.DeleteBlobContainer(context.Background(), test.subsID, test.rg, test.accountName, test.containerName, test.secrets, "")
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("test(%s), actualErr: (%v), expectedErr: (%v)", test.desc, err, test.expectedErr)
 		}
@@ -2432,7 +2478,7 @@ func TestCleanupContainerOnFailure(t *testing.T) {
 				Times(expectedCalls)
 
 			// Act. Must not panic even when the delete errors out (best-effort).
-			d.cleanupContainerOnFailure(test.shouldCleanup, "subsID", "rg", testAccount, testContainer, map[string]string{}, []string{}, "unit-test")
+			d.cleanupContainerOnFailure(test.shouldCleanup, "subsID", "rg", testAccount, testContainer, map[string]string{}, []string{}, "", "unit-test")
 
 			if deleteCalls != expectedCalls {
 				t.Errorf("DeleteContainer call count = %d, expected %d", deleteCalls, expectedCalls)

--- a/pkg/blob/controllerserver_test.go
+++ b/pkg/blob/controllerserver_test.go
@@ -1675,8 +1675,7 @@ func TestDeleteBlobContainer(t *testing.T) {
 			accountName:     "accountName",
 			secrets:         map[string]string{},
 			useDataPlaneAPI: oauth,
-			expectedErr: fmt.Errorf("failed to delete container(%s) on account(%s), error: %w", "containerName", "accountName",
-				fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth)),
+			expectedErr:     fmt.Errorf("useDataPlaneAPI is set to %q but AuthProvider is not configured", oauth),
 		},
 	}
 

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1037,8 +1037,8 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			Pod:                 pod,
 			PodWithClonedVolume: podWithClonedVolume,
 			StorageClassParameters: map[string]string{
-				"skuName": "Standard_LRS",
-				"protocol": "fuse2",
+				"skuName":         "Standard_LRS",
+				"protocol":        "fuse2",
 				"useDataPlaneAPI": "oauth",
 			},
 		}
@@ -1070,8 +1070,8 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			Pod:                 pod,
 			PodWithClonedVolume: podWithClonedVolume,
 			StorageClassParameters: map[string]string{
-				"skuName": "Standard_LRS",
-				"protocol": "fuse2",
+				"skuName":         "Standard_LRS",
+				"protocol":        "fuse2",
 				"useDataPlaneAPI": "oauth",
 			},
 		}

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -506,8 +506,9 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
-				"skuName":   "Standard_LRS",
-				"matchTags": "true",
+				"skuName":         "Standard_LRS",
+				"matchTags":       "true",
+				"useDataPlaneAPI": "oauth",
 			},
 		}
 		test.Run(ctx, cs, ns)
@@ -591,6 +592,7 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 				"protocol":            "nfs",
 				"mountPermissions":    "0755",
 				"fsGroupChangePolicy": "Always",
+				"useDataPlaneAPI":     "oauth",
 			},
 		}
 		test.Run(ctx, cs, ns)

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -59,18 +59,6 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		testDriver = driver.InitBlobCSIDriver()
 	})
 
-	ensureOAuthControllerDataRole := func(ctx ginkgo.SpecContext) {
-		if !isCapzTest {
-			ginkgo.Skip("test case is only available for CAPZ test")
-		}
-		creds, err := credentials.CreateAzureCredentialFile()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		azureClient, err := azure.GetClient(creds.Cloud, creds.SubscriptionID, creds.AADClientID, creds.TenantID, creds.AADClientSecret, creds.AADFederatedTokenFile)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = azureClient.EnsureNodeStorageBlobDataRole(ctx, creds.ResourceGroup)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to assign Storage Blob Data Contributor role to controller identity")
-	}
-
 	ginkgo.It("should create a volume on demand without saving storage account key", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{
@@ -525,34 +513,6 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
-	ginkgo.It("should create a volume on demand and resize it with oauth data plane [blob.csi.azure.com]", func(ctx ginkgo.SpecContext) {
-		ensureOAuthControllerDataRole(ctx)
-		pods := []testsuites.PodDetails{
-			{
-				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
-				Volumes: []testsuites.VolumeDetails{
-					{
-						ClaimSize: "10Gi",
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			CSIDriver: testDriver,
-			Pods:      pods,
-			StorageClassParameters: map[string]string{
-				"skuName":         "Standard_LRS",
-				"matchTags":       "true",
-				"useDataPlaneAPI": "oauth",
-			},
-		}
-		test.Run(ctx, cs, ns)
-	})
-
 	ginkgo.It("should create an CSI inline volume [blob.csi.azure.com]", func(ctx ginkgo.SpecContext) {
 		// create a volume
 		containerName := "csi-inline-blobfuse-volume"
@@ -631,44 +591,6 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 				"protocol":            "nfs",
 				"mountPermissions":    "0755",
 				"fsGroupChangePolicy": "Always",
-			},
-		}
-		test.Run(ctx, cs, ns)
-	})
-
-	ginkgo.It("should create a NFSv3 volume on demand with mount options and fsGroup using oauth data plane [nfs]", func(ctx ginkgo.SpecContext) {
-		ensureOAuthControllerDataRole(ctx)
-		if isAzureStackCloud {
-			ginkgo.Skip("test case is not available for Azure Stack")
-		}
-		fsGroup := int64(1000)
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:     "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
-				FSGroup: &fsGroup,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						ClaimSize: "10Gi",
-						MountOptions: []string{
-							"nconnect=8",
-						},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
-		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
-			CSIDriver: testDriver,
-			Pods:      pods,
-			StorageClassParameters: map[string]string{
-				"skuName":             "Premium_LRS",
-				"protocol":            "nfs",
-				"mountPermissions":    "0755",
-				"fsGroupChangePolicy": "Always",
-				"useDataPlaneAPI":     "oauth",
 			},
 		}
 		test.Run(ctx, cs, ns)
@@ -1115,8 +1037,9 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			Pod:                 pod,
 			PodWithClonedVolume: podWithClonedVolume,
 			StorageClassParameters: map[string]string{
-				"skuName":  "Standard_LRS",
+				"skuName": "Standard_LRS",
 				"protocol": "fuse2",
+				"useDataPlaneAPI": "oauth",
 			},
 		}
 		test.Run(ctx, cs, ns)
@@ -1147,8 +1070,9 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			Pod:                 pod,
 			PodWithClonedVolume: podWithClonedVolume,
 			StorageClassParameters: map[string]string{
-				"skuName":  "Standard_LRS",
+				"skuName": "Standard_LRS",
 				"protocol": "fuse2",
+				"useDataPlaneAPI": "oauth",
 			},
 		}
 		test.Run(ctx, cs, ns)

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -59,6 +59,18 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		testDriver = driver.InitBlobCSIDriver()
 	})
 
+	ensureOAuthControllerDataRole := func(ctx ginkgo.SpecContext) {
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for CAPZ test")
+		}
+		creds, err := credentials.CreateAzureCredentialFile()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		azureClient, err := azure.GetClient(creds.Cloud, creds.SubscriptionID, creds.AADClientID, creds.TenantID, creds.AADClientSecret, creds.AADFederatedTokenFile)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = azureClient.EnsureNodeStorageBlobDataRole(ctx, creds.ResourceGroup)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to assign Storage Blob Data Contributor role to controller identity")
+	}
+
 	ginkgo.It("should create a volume on demand without saving storage account key", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{
@@ -506,6 +518,33 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 			CSIDriver: testDriver,
 			Pods:      pods,
 			StorageClassParameters: map[string]string{
+				"skuName":   "Standard_LRS",
+				"matchTags": "true",
+			},
+		}
+		test.Run(ctx, cs, ns)
+	})
+
+	ginkgo.It("should create a volume on demand and resize it with oauth data plane [blob.csi.azure.com]", func(ctx ginkgo.SpecContext) {
+		ensureOAuthControllerDataRole(ctx)
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			CSIDriver: testDriver,
+			Pods:      pods,
+			StorageClassParameters: map[string]string{
 				"skuName":         "Standard_LRS",
 				"matchTags":       "true",
 				"useDataPlaneAPI": "oauth",
@@ -562,6 +601,43 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 	})
 
 	ginkgo.It("should create a NFSv3 volume on demand with mount options and fsGroup [nfs]", func(ctx ginkgo.SpecContext) {
+		if isAzureStackCloud {
+			ginkgo.Skip("test case is not available for Azure Stack")
+		}
+		fsGroup := int64(1000)
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:     "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				FSGroup: &fsGroup,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"nconnect=8",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: testDriver,
+			Pods:      pods,
+			StorageClassParameters: map[string]string{
+				"skuName":             "Premium_LRS",
+				"protocol":            "nfs",
+				"mountPermissions":    "0755",
+				"fsGroupChangePolicy": "Always",
+			},
+		}
+		test.Run(ctx, cs, ns)
+	})
+
+	ginkgo.It("should create a NFSv3 volume on demand with mount options and fsGroup using oauth data plane [nfs]", func(ctx ginkgo.SpecContext) {
+		ensureOAuthControllerDataRole(ctx)
 		if isAzureStackCloud {
 			ginkgo.Skip("test case is not available for Azure Stack")
 		}


### PR DESCRIPTION
## Description
This adds support for `useDataPlaneAPI: oauth` in StorageClass parameters.

## Motivation
Storage accounts with firewall/VNet restrictions or `publicNetworkAccess=Disabled` cannot be accessed via shared-key data plane APIs. On AKS-managed CSI drivers, the driver's managed identity carries a trusted-service claim that Storage firewall accepts as bypass (when `networkAcls.bypass` includes `AzureServices`). This PR enables the blob CSI driver to leverage that OAuth token for container CRUD operations.

## Changes
- **`pkg/blob/blob.go`**: Add `oauth` constant; change `useDataPlaneAPI()` return type from `bool` to `string` (returns `""`, `"true"`, or `"oauth"`)
- **`pkg/blob/controllerserver.go`**:
  - Change `useDataPlaneAPI` local variable from `bool` to `string`
  - Add tri-state parsing: accepts `true`/`false`/`oauth`, rejects others with `InvalidArgument`
  - Add OAuth branch in `CreateBlobContainer` using `azblob/container.NewClient(url, tokenCredential, nil)` + `client.Create()`
  - Add OAuth branch in `DeleteBlobContainer` using `azblob/container.NewClient(url, tokenCredential, nil)` + `client.Delete()`
  - Store `useDataPlaneAPI` string value in cache (instead of empty string) for proper tri-state retrieval in `DeleteVolume` path
  - Thread `useDataPlaneAPI` parameter through `cleanupContainerOnFailure`
- **`docs/driver-parameters.md`**: Update `useDataPlaneAPI` row; add "Using useDataPlaneAPI: oauth against private storage accounts" section
- **Tests**: Update `TestUseDataPlaneAPI`, `TestCreateBlobContainer`, `TestDeleteBlobContainer`, `TestCleanupContainerOnFailure` for new signatures; add `invalid useDataPlaneAPI value` and `valid useDataPlaneAPI oauth value` test cases

## Scope
- **CreateContainer**: Fully supports OAuth path
- **DeleteContainer**: Fully supports OAuth path
- **DeleteVolume**: Uses cached `useDataPlaneAPI` value to determine which path to use

## Backwards Compatibility
- Default behavior unchanged (`false` or empty = management plane SRP)
- `true` = shared-key data plane (existing behavior preserved)
- `oauth` = new OAuth data plane path

## Required RBAC
The driver's managed identity must have `Storage Blob Data Contributor` (or higher) role on the target storage account.

## Testing
- `go build ./...` ✅
- `go test ./pkg/blob/... -count=1` ✅