### PR TITLE
fix: validate volume attribute keys and containerName in NodeStageVolume

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1493,12 +1493,12 @@ func createStorageAccountSecret(account, key string) map[string]string {
 	return secret
 }
 
-// NormalizeVolumeAttributes checks that no two keys in the map collide under
+// ValidateVolumeAttributeKeys checks that no two keys in the map collide under
 // case-insensitive comparison with different values. If a collision is found
 // an error is returned. The original map is returned unmodified so that
 // existing direct map lookups (e.g. context[ephemeralField]) continue to work
 // without any change in behaviour.
-func NormalizeVolumeAttributes(attrib map[string]string) (map[string]string, error) {
+func ValidateVolumeAttributeKeys(attrib map[string]string) (map[string]string, error) {
 	if attrib == nil {
 		return nil, nil
 	}

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1493,9 +1493,6 @@ func createStorageAccountSecret(account, key string) map[string]string {
 	return secret
 }
 
-// setKeyValueInMap set key/value pair in map
-// key in the map is case insensitive, if key already exists, overwrite existing value
-
 // NormalizeVolumeAttributes returns a new map with all keys lowercased.
 // If two keys collide after lowercasing with different values, an error is
 // returned. This ensures all code paths that read volumeAttributes resolve
@@ -1509,7 +1506,7 @@ func NormalizeVolumeAttributes(attrib map[string]string) (map[string]string, err
 		lower := strings.ToLower(k)
 		if existing, ok := normalized[lower]; ok {
 			if existing != v {
-				return nil, fmt.Errorf("conflicting volume attribute: key %q collides with another key after case-insensitive normalization (values %q vs %q)", k, existing, v)
+				return nil, fmt.Errorf("conflicting volume attribute: key %q collides with another key (case-insensitive) with a different value", lower)
 			}
 			continue
 		}
@@ -1518,6 +1515,8 @@ func NormalizeVolumeAttributes(attrib map[string]string) (map[string]string, err
 	return normalized, nil
 }
 
+// setKeyValueInMap set key/value pair in map
+// key in the map is case insensitive, if key already exists, overwrite existing value
 func setKeyValueInMap(m map[string]string, key, value string) {
 	if m == nil {
 		return

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1493,26 +1493,26 @@ func createStorageAccountSecret(account, key string) map[string]string {
 	return secret
 }
 
-// NormalizeVolumeAttributes returns a new map with all keys lowercased.
-// If two keys collide after lowercasing with different values, an error is
-// returned. This ensures all code paths that read volumeAttributes resolve
-// the same deterministic value for each logical key.
+// NormalizeVolumeAttributes checks that no two keys in the map collide under
+// case-insensitive comparison with different values. If a collision is found
+// an error is returned. The original map is returned unmodified so that
+// existing direct map lookups (e.g. context[ephemeralField]) continue to work
+// without any change in behaviour.
 func NormalizeVolumeAttributes(attrib map[string]string) (map[string]string, error) {
 	if attrib == nil {
 		return nil, nil
 	}
-	normalized := make(map[string]string, len(attrib))
+	seen := make(map[string]string, len(attrib))
 	for k, v := range attrib {
 		lower := strings.ToLower(k)
-		if existing, ok := normalized[lower]; ok {
+		if existing, ok := seen[lower]; ok {
 			if existing != v {
 				return nil, fmt.Errorf("conflicting volume attribute: key %q collides with another key (case-insensitive) with a different value", lower)
 			}
-			continue
 		}
-		normalized[lower] = v
+		seen[lower] = v
 	}
-	return normalized, nil
+	return attrib, nil
 }
 
 // setKeyValueInMap set key/value pair in map

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1495,6 +1495,29 @@ func createStorageAccountSecret(account, key string) map[string]string {
 
 // setKeyValueInMap set key/value pair in map
 // key in the map is case insensitive, if key already exists, overwrite existing value
+
+// NormalizeVolumeAttributes returns a new map with all keys lowercased.
+// If two keys collide after lowercasing with different values, an error is
+// returned. This ensures all code paths that read volumeAttributes resolve
+// the same deterministic value for each logical key.
+func NormalizeVolumeAttributes(attrib map[string]string) (map[string]string, error) {
+	if attrib == nil {
+		return nil, nil
+	}
+	normalized := make(map[string]string, len(attrib))
+	for k, v := range attrib {
+		lower := strings.ToLower(k)
+		if existing, ok := normalized[lower]; ok {
+			if existing != v {
+				return nil, fmt.Errorf("conflicting volume attribute: key %q collides with another key after case-insensitive normalization (values %q vs %q)", k, existing, v)
+			}
+			continue
+		}
+		normalized[lower] = v
+	}
+	return normalized, nil
+}
+
 func setKeyValueInMap(m map[string]string, key, value string) {
 	if m == nil {
 		return

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -80,6 +80,15 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
+
+	// Normalize volume attributes: lowercase all keys and reject maps with
+	// case-colliding keys that carry different values.
+	var err error
+	context, err = NormalizeVolumeAttributes(context)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
+	}
+
 	serviceAccountTokens := getServiceAccountTokens(secrets, context)
 	if context != nil {
 		// token request
@@ -304,6 +313,15 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 	volumeMountGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
 	attrib := req.GetVolumeContext()
+
+	// Normalize volume attributes: lowercase all keys and reject maps with
+	// case-colliding keys that carry different values.
+	var err error
+	attrib, err = NormalizeVolumeAttributes(attrib)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+	}
+
 	secrets := req.GetSecrets()
 	serviceAccountTokens := getServiceAccountTokens(secrets, attrib)
 

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -81,10 +81,10 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
 
-	// Normalize volume attributes: lowercase all keys and reject maps with
-	// case-colliding keys that carry different values.
+	// Validate volume attribute keys: reject maps with case-colliding keys
+	// that carry different values.
 	var err error
-	context, err = NormalizeVolumeAttributes(context)
+	context, err = ValidateVolumeAttributeKeys(context)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
 	}
@@ -314,10 +314,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	volumeMountGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
 	attrib := req.GetVolumeContext()
 
-	// Normalize volume attributes: lowercase all keys and reject maps with
-	// case-colliding keys that carry different values.
+	// Validate volume attribute keys: reject maps with case-colliding keys
+	// that carry different values.
 	var err error
-	attrib, err = NormalizeVolumeAttributes(attrib)
+	attrib, err = ValidateVolumeAttributeKeys(attrib)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
 	}

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -983,6 +983,33 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "[Error] conflicting case-variant volume attribute keys are rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						"clientid":            "value-a",
+						"ClientID":            "value-b",
+						containerNameField:    "testcontainer",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err == nil {
+					t.Fatal("expected InvalidArgument error for conflicting case-variant keys, got nil")
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+			},
+		},
+		{
 			name: "[Error] inline volume with invalid containerName is rejected",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{

--- a/pkg/blob/normalize_test.go
+++ b/pkg/blob/normalize_test.go
@@ -119,7 +119,7 @@ func TestValidateContainerNameAdditional(t *testing.T) {
 		{name: "empty allowed", input: "", wantErr: false},
 		{name: "too short", input: "ab", wantErr: true},
 		{name: "consecutive hyphens", input: "my--container", wantErr: true},
-		{name: "contains spaces", input: "a]b c", wantErr: true},
+		{name: "contains spaces", input: "abc def", wantErr: true},
 		{name: "contains tab", input: "abc\tdef", wantErr: true},
 		{name: "uppercase", input: "MyContainer", wantErr: true},
 		{name: "starts with hyphen", input: "-container", wantErr: true},

--- a/pkg/blob/normalize_test.go
+++ b/pkg/blob/normalize_test.go
@@ -54,13 +54,13 @@ func TestNormalizeVolumeAttributes(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "case-colliding keys with same values should deduplicate",
+			name: "case-colliding keys with same values should pass",
 			input: map[string]string{
 				"clientID": "same",
 				"ClientID": "same",
 			},
 			wantErr: false,
-			wantLen: 1,
+			wantLen: 2,
 		},
 		{
 			name: "mixed case keys no collision",
@@ -95,14 +95,6 @@ func TestNormalizeVolumeAttributes(t *testing.T) {
 			}
 			if len(result) != tc.wantLen {
 				t.Errorf("expected %d keys, got %d", tc.wantLen, len(result))
-			}
-			for k := range result {
-				for _, c := range k {
-					if c >= 'A' && c <= 'Z' {
-						t.Errorf("key %q contains uppercase characters", k)
-						break
-					}
-				}
 			}
 		})
 	}

--- a/pkg/blob/normalize_test.go
+++ b/pkg/blob/normalize_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"testing"
+)
+
+func TestNormalizeVolumeAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name:    "nil map",
+			input:   nil,
+			wantErr: false,
+			wantLen: 0,
+		},
+		{
+			name:    "empty map",
+			input:   map[string]string{},
+			wantErr: false,
+			wantLen: 0,
+		},
+		{
+			name:    "no collisions",
+			input:   map[string]string{"clientid": "abc", "tenantid": "def"},
+			wantErr: false,
+			wantLen: 2,
+		},
+		{
+			name: "case-colliding keys with different values should error",
+			input: map[string]string{
+				"clientID": "value-a",
+				"ClientID": "value-b",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case-colliding keys with same values should deduplicate",
+			input: map[string]string{
+				"clientID": "same",
+				"ClientID": "same",
+			},
+			wantErr: false,
+			wantLen: 1,
+		},
+		{
+			name: "mixed case keys no collision",
+			input: map[string]string{
+				"StorageAccount": "myaccount",
+				"containerName":  "mycontainer",
+				"protocol":       "fuse2",
+			},
+			wantErr: false,
+			wantLen: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := NormalizeVolumeAttributes(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if tc.input == nil {
+				if result != nil {
+					t.Errorf("expected nil result for nil input")
+				}
+				return
+			}
+			if len(result) != tc.wantLen {
+				t.Errorf("expected %d keys, got %d", tc.wantLen, len(result))
+			}
+			for k := range result {
+				for _, c := range k {
+					if c >= 'A' && c <= 'Z' {
+						t.Errorf("key %q contains uppercase characters", k)
+						break
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateContainerNameAdditional(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "valid", input: "mycontainer", wantErr: false},
+		{name: "valid with hyphens", input: "my-container-123", wantErr: false},
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "too short", input: "ab", wantErr: true},
+		{name: "consecutive hyphens", input: "my--container", wantErr: true},
+		{name: "contains spaces", input: "a]b c", wantErr: true},
+		{name: "contains tab", input: "abc\tdef", wantErr: true},
+		{name: "uppercase", input: "MyContainer", wantErr: true},
+		{name: "starts with hyphen", input: "-container", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateContainerName(tc.input)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %q", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.input, err)
+			}
+		})
+	}
+}

--- a/pkg/blob/validate_volume_attributes_test.go
+++ b/pkg/blob/validate_volume_attributes_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestNormalizeVolumeAttributes(t *testing.T) {
+func TestValidateVolumeAttributeKeys(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   map[string]string
@@ -76,7 +76,7 @@ func TestNormalizeVolumeAttributes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := NormalizeVolumeAttributes(tc.input)
+			result, err := ValidateVolumeAttributeKeys(tc.input)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("expected error but got nil")


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
- Adds `ValidateVolumeAttributeKeys` to detect case-insensitive key collisions with different values in the `volumeAttributes` map. Called at the entry of both `NodePublishVolume` and `NodeStageVolume`.
- The original map is returned unmodified — no key lowercasing or deduplication — so existing direct map lookups continue to work without any behavior change.

Multiple code paths independently iterate `volumeAttributes` with case-insensitive key matching. Since Go map iteration order is randomized, if two keys differ only by case with different values, independent loops can resolve to different values. This validation rejects such ambiguous inputs early.

## How does this PR change things
- If `volumeAttributes` contains two keys that differ only by case with different values (e.g. `clientID` and `ClientID`), the request is rejected with `InvalidArgument`.
- If they have the same value, the request proceeds normally.
- No behavior change for well-formed requests.

## Testing
- Added unit tests for `ValidateVolumeAttributeKeys` covering nil, empty, no collision, case-collision with different values, case-collision with same values, and mixed-case no collision.
- Added unit tests for `ValidateContainerName`.
- Added integration test `conflicting case-variant volume attribute keys are rejected` in `NodeStageVolume`.