### PR TITLE
fix: ensure consistent volume attribute key resolution across code paths

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1495,6 +1495,28 @@ func createStorageAccountSecret(account, key string) map[string]string {
 
 // setKeyValueInMap set key/value pair in map
 // key in the map is case insensitive, if key already exists, overwrite existing value
+// NormalizeVolumeAttributes returns a new map with all keys lowercased.
+// If two keys collide after lowercasing with different values, an error is
+// returned. This ensures every code path that reads volumeAttributes sees
+// the same deterministic value for a given logical key.
+func NormalizeVolumeAttributes(attrib map[string]string) (map[string]string, error) {
+	if attrib == nil {
+		return nil, nil
+	}
+	normalized := make(map[string]string, len(attrib))
+	for k, v := range attrib {
+		lower := strings.ToLower(k)
+		if existing, ok := normalized[lower]; ok {
+			if existing != v {
+				return nil, fmt.Errorf("conflicting volume attribute: key %q collides with another key after case-insensitive normalization (values %q vs %q)", k, existing, v)
+			}
+			continue
+		}
+		normalized[lower] = v
+	}
+	return normalized, nil
+}
+
 func setKeyValueInMap(m map[string]string, key, value string) {
 	if m == nil {
 		return

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -80,6 +80,16 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
+
+	// Normalize volume attributes: lowercase all keys and reject maps with
+	// case-colliding keys that carry different values, ensuring consistent
+	// resolution across all code paths.
+	var err error
+	context, err = NormalizeVolumeAttributes(context)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
+	}
+
 	serviceAccountTokens := getServiceAccountTokens(secrets, context)
 	if context != nil {
 		// token request
@@ -304,6 +314,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 	volumeMountGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
 	attrib := req.GetVolumeContext()
+
+	// Normalize volume attributes: lowercase all keys and reject maps with
+	// case-colliding keys that carry different values, ensuring consistent
+	// resolution across useWorkloadIdentity and GetAuthEnv.
+	var err error
+	attrib, err = NormalizeVolumeAttributes(attrib)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+	}
+
 	secrets := req.GetSecrets()
 	serviceAccountTokens := getServiceAccountTokens(secrets, attrib)
 

--- a/pkg/blob/normalize_test.go
+++ b/pkg/blob/normalize_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package blob
+
+import (
+	"testing"
+)
+
+func TestNormalizeVolumeAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name:    "nil map",
+			input:   nil,
+			wantErr: false,
+			wantLen: 0,
+		},
+		{
+			name:    "empty map",
+			input:   map[string]string{},
+			wantErr: false,
+			wantLen: 0,
+		},
+		{
+			name:    "no collisions",
+			input:   map[string]string{"clientid": "abc", "tenantid": "def"},
+			wantErr: false,
+			wantLen: 2,
+		},
+		{
+			name: "case-colliding keys with different values should error",
+			input: map[string]string{
+				"clientID": "value-a",
+				"ClientID": "value-b",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case-colliding keys with same values should deduplicate",
+			input: map[string]string{
+				"clientID": "same",
+				"ClientID": "same",
+			},
+			wantErr: false,
+			wantLen: 1,
+		},
+		{
+			name: "mixed case keys no collision",
+			input: map[string]string{
+				"StorageAccount": "myaccount",
+				"containerName":  "mycontainer",
+				"protocol":       "fuse2",
+			},
+			wantErr: false,
+			wantLen: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := NormalizeVolumeAttributes(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if tc.input == nil {
+				if result != nil {
+					t.Errorf("expected nil result for nil input")
+				}
+				return
+			}
+			if len(result) != tc.wantLen {
+				t.Errorf("expected %d keys, got %d", tc.wantLen, len(result))
+			}
+			for k := range result {
+				for _, c := range k {
+					if c >= 'A' && c <= 'Z' {
+						t.Errorf("key %q contains uppercase characters", k)
+						break
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add NormalizeVolumeAttributes to lowercase and deduplicate keys in the volumeAttributes map at the entry of NodePublishVolume and NodeStageVolume. This ensures all downstream consumers (useWorkloadIdentity, GetAuthEnv, ephemeral detection, etc.) resolve the same deterministic value for each logical key.

- Add unit tests for NormalizeVolumeAttributes.