### PR TITLE
Cherry-pick #2603 to release-1.27: validate volume attribute keys and containerName

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1493,6 +1493,28 @@ func createStorageAccountSecret(account, key string) map[string]string {
 	return secret
 }
 
+// ValidateVolumeAttributeKeys checks that no two keys in the map collide under
+// case-insensitive comparison with different values. If a collision is found
+// an error is returned. The original map is returned unmodified so that
+// existing direct map lookups (e.g. context[ephemeralField]) continue to work
+// without any change in behaviour.
+func ValidateVolumeAttributeKeys(attrib map[string]string) (map[string]string, error) {
+	if attrib == nil {
+		return nil, nil
+	}
+	seen := make(map[string]string, len(attrib))
+	for k, v := range attrib {
+		lower := strings.ToLower(k)
+		if existing, ok := seen[lower]; ok {
+			if existing != v {
+				return nil, fmt.Errorf("conflicting volume attribute: key %q collides with another key (case-insensitive) with a different value", lower)
+			}
+		}
+		seen[lower] = v
+	}
+	return attrib, nil
+}
+
 // setKeyValueInMap set key/value pair in map
 // key in the map is case insensitive, if key already exists, overwrite existing value
 func setKeyValueInMap(m map[string]string, key, value string) {

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -78,6 +78,15 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
+
+	// Validate volume attribute keys: reject maps with case-colliding keys
+	// that carry different values.
+	var err error
+	context, err = ValidateVolumeAttributeKeys(context)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
+	}
+
 	if context != nil {
 		// token request
 		if context[serviceAccountTokenField] != "" && useWorkloadIdentity(context) {
@@ -300,6 +309,15 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 	volumeMountGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
 	attrib := req.GetVolumeContext()
+
+	// Validate volume attribute keys: reject maps with case-colliding keys
+	// that carry different values.
+	var err error
+	attrib, err = ValidateVolumeAttributeKeys(attrib)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+	}
+
 	secrets := req.GetSecrets()
 
 	if useWorkloadIdentity(attrib) && attrib[serviceAccountTokenField] == "" {

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -81,11 +81,11 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	// Validate volume attribute keys: reject maps with case-colliding keys
 	// that carry different values.
-	var err error
-	context, err = ValidateVolumeAttributeKeys(context)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
+	validatedContext, verr := ValidateVolumeAttributeKeys(context)
+	if verr != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", verr)
 	}
+	context = validatedContext
 
 	if context != nil {
 		// token request
@@ -312,11 +312,11 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 	// Validate volume attribute keys: reject maps with case-colliding keys
 	// that carry different values.
-	var err error
-	attrib, err = ValidateVolumeAttributeKeys(attrib)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+	validatedAttrib, verr := ValidateVolumeAttributeKeys(attrib)
+	if verr != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", verr)
 	}
+	attrib = validatedAttrib
 
 	secrets := req.GetSecrets()
 

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -956,6 +956,33 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "[Error] conflicting case-variant volume attribute keys are rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						"clientid":            "value-a",
+						"ClientID":            "value-b",
+						containerNameField:    "testcontainer",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err == nil {
+					t.Fatal("expected InvalidArgument error for conflicting case-variant keys, got nil")
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+			},
+		},
+		{
 			name: "[Error] inline volume with invalid containerName is rejected",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{

--- a/pkg/blob/validate_volume_attributes_test.go
+++ b/pkg/blob/validate_volume_attributes_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"testing"
+)
+
+func TestValidateVolumeAttributeKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name:    "nil map",
+			input:   nil,
+			wantErr: false,
+			wantLen: 0,
+		},
+		{
+			name:    "empty map",
+			input:   map[string]string{},
+			wantErr: false,
+			wantLen: 0,
+		},
+		{
+			name:    "no collisions",
+			input:   map[string]string{"clientid": "abc", "tenantid": "def"},
+			wantErr: false,
+			wantLen: 2,
+		},
+		{
+			name: "case-colliding keys with different values should error",
+			input: map[string]string{
+				"clientID": "value-a",
+				"ClientID": "value-b",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case-colliding keys with same values should pass",
+			input: map[string]string{
+				"clientID": "same",
+				"ClientID": "same",
+			},
+			wantErr: false,
+			wantLen: 2,
+		},
+		{
+			name: "mixed case keys no collision",
+			input: map[string]string{
+				"StorageAccount": "myaccount",
+				"containerName":  "mycontainer",
+				"protocol":       "fuse2",
+			},
+			wantErr: false,
+			wantLen: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ValidateVolumeAttributeKeys(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if tc.input == nil {
+				if result != nil {
+					t.Errorf("expected nil result for nil input")
+				}
+				return
+			}
+			if len(result) != tc.wantLen {
+				t.Errorf("expected %d keys, got %d", tc.wantLen, len(result))
+			}
+		})
+	}
+}
+
+func TestValidateContainerNameAdditional(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "valid", input: "mycontainer", wantErr: false},
+		{name: "valid with hyphens", input: "my-container-123", wantErr: false},
+		{name: "empty allowed", input: "", wantErr: false},
+		{name: "too short", input: "ab", wantErr: true},
+		{name: "consecutive hyphens", input: "my--container", wantErr: true},
+		{name: "contains spaces", input: "abc def", wantErr: true},
+		{name: "contains tab", input: "abc\tdef", wantErr: true},
+		{name: "uppercase", input: "MyContainer", wantErr: true},
+		{name: "starts with hyphen", input: "-container", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateContainerName(tc.input)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %q", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.input, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #2603 to release-1.27.

**Original PR**: kubernetes-sigs/blob-csi-driver#2603 (merged as db6bff86694092690837d2cb6135e97a3e53d093)

**What**: Adds `ValidateVolumeAttributeKeys` to reject `VolumeAttributes` maps containing case-colliding keys with different values, and unconditionally validates `containerName`.

**Why**: Fixes two security issues (case-variant key attacks):
1. **Container name injection → arbitrary node directory deletion** via `ephemeralField` case-variance flipping the ephemeral flag off so `ValidateContainerName` is skipped.
2. **Workload identity bypass → unauthorized storage access** via `clientID` / `ClientID` case-variance where `getValueInMap` (first-match) and `GetAuthEnv` (last-wins) disagree, causing WI to be silently bypassed.

**Conflict resolution**: The only conflict was in `pkg/blob/nodeserver.go` `NodePublishVolume` — resolved by inserting the `ValidateVolumeAttributeKeys` block after `context := req.GetVolumeContext()` and omitting the `serviceAccountTokens := getServiceAccountTokens(...)` line (that helper doesn't exist on this branch; token check uses `context[serviceAccountTokenField]` directly).

/kind bug
/priority important-soon
