### PR TITLE
bump github/codeql-action init+analyze from 4.37.5 to 4.37.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@85689a103d1234521562bbb736b2c4a31c9a85d5 # v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4


### PR DESCRIPTION
What this PR does / why we need it:

Bumps [github/codeql-action](https://github.com/github/codeql-action) init and analyze together to 4.37.6 (`5595cca`) in a single commit.

Both init and analyze must be bumped together — init writes a config file tagged with its own version and analyze refuses to run when the two do not match.

This follows the same pattern as kubernetes-csi/csi-driver-smb#1178.

**Does this PR introduce a user-facing change?**

NONE
