### PR TITLE
fix: harden server field handling in inline volume with managed identity auth mount

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1349,7 +1349,7 @@ func isAzureDNSZoneStorageHost(host, account string) bool {
 		return false
 	}
 	if len(zoneID) == 2 &&
-		(zoneID[0] < '0' || zoneID[0] > '9' ||
+		(zoneID[0] < '1' || zoneID[0] > '9' ||
 			zoneID[1] < '0' || zoneID[1] > '9') {
 		return false
 	}

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1306,6 +1306,8 @@ func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSu
 	}
 
 	secondaryAccount := account + "-secondary"
+	// Secondary DFS forms are accepted for structural consistency. They do not
+	// currently resolve for HNS accounts because HNS does not support RA-GRS.
 	allowedHosts := map[string]struct{}{
 		fmt.Sprintf("%s.blob.%s", account, suffix):                      {},
 		fmt.Sprintf("%s.dfs.%s", account, suffix):                       {},
@@ -1319,7 +1321,8 @@ func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSu
 	if _, ok := allowedHosts[host]; ok {
 		return nil
 	}
-	if suffix == defaultStorageEndPointSuffix && isAzureDNSZoneStorageHost(host, account) {
+	if suffix == defaultStorageEndPointSuffix &&
+		isAzureDNSZoneStorageHost(host, account) {
 		return nil
 	}
 
@@ -1330,20 +1333,41 @@ func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSu
 // format without requiring a storage management-plane lookup from the node.
 func isAzureDNSZoneStorageHost(host, account string) bool {
 	parts := strings.Split(host, ".")
-	if len(parts) != 6 {
+	if len(parts) != 6 && len(parts) != 7 {
 		return false
 	}
 	if parts[0] != account && parts[0] != account+"-secondary" {
 		return false
 	}
 	zone := parts[1]
-	if len(zone) != 3 || zone[0] != 'z' || zone[1] < '0' || zone[1] > '9' || zone[2] < '0' || zone[2] > '9' {
+	zoneID, hasZonePrefix := strings.CutPrefix(zone, "z")
+	if !hasZonePrefix {
 		return false
 	}
-	if parts[2] != "blob" && parts[2] != "dfs" {
+	if len(zoneID) == 1 &&
+		(zoneID[0] < '1' || zoneID[0] > '9') {
 		return false
 	}
-	return parts[3] == "storage" && parts[4] == "azure" && parts[5] == "net"
+	if len(zoneID) == 2 &&
+		(zoneID[0] < '0' || zoneID[0] > '9' ||
+			zoneID[1] < '0' || zoneID[1] > '9') {
+		return false
+	}
+	if len(zoneID) < 1 || len(zoneID) > 2 {
+		return false
+	}
+
+	serviceIndex := 2
+	if len(parts) == 7 {
+		if parts[serviceIndex] != "privatelink" {
+			return false
+		}
+		serviceIndex++
+	}
+	if parts[serviceIndex] != "blob" && parts[serviceIndex] != "dfs" {
+		return false
+	}
+	return strings.Join(parts[serviceIndex+1:], ".") == "storage.azure.net"
 }
 
 // parseInlineVolumeServer extracts a normalized hostname from an HTTPS server

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1279,6 +1281,98 @@ func ValidateContainerName(containerName string) error {
 		return fmt.Errorf("invalid containerName %q: consecutive hyphens are not allowed", containerName)
 	}
 	return nil
+}
+
+// ValidateInlineVolumeServer ensures a namespace-controlled inline volume can
+// only direct storage traffic to the resolved account in the configured cloud.
+func ValidateInlineVolumeServer(server, accountName, storageEndpointSuffix string) error {
+	_, err := normalizeInlineVolumeServer(server, accountName, storageEndpointSuffix)
+	return err
+}
+
+func normalizeInlineVolumeServer(server, accountName, storageEndpointSuffix string, accountEndpoints ...string) (string, error) {
+	host, err := parseInlineVolumeServer(server)
+	if err != nil {
+		return "", err
+	}
+	if err := validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix, accountEndpoints...); err != nil {
+		return "", err
+	}
+	return host, nil
+}
+
+func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix string, accountEndpoints ...string) error {
+	account := strings.ToLower(strings.TrimSpace(accountName))
+	suffix := strings.ToLower(strings.Trim(strings.TrimSpace(storageEndpointSuffix), "."))
+	if account == "" || suffix == "" {
+		return fmt.Errorf("cannot validate server %q without a storage account and endpoint suffix", server)
+	}
+
+	allowedHosts := map[string]struct{}{
+		fmt.Sprintf("%s.blob.%s", account, suffix):             {},
+		fmt.Sprintf("%s.dfs.%s", account, suffix):              {},
+		fmt.Sprintf("%s.privatelink.blob.%s", account, suffix): {},
+		fmt.Sprintf("%s.privatelink.dfs.%s", account, suffix):  {},
+	}
+	for _, endpoint := range accountEndpoints {
+		endpointURL, err := url.Parse(endpoint)
+		if err != nil {
+			continue
+		}
+		if endpointHost := strings.ToLower(strings.TrimSuffix(endpointURL.Hostname(), ".")); endpointHost != "" {
+			allowedHosts[endpointHost] = struct{}{}
+		}
+	}
+	if _, ok := allowedHosts[host]; !ok {
+		return fmt.Errorf("invalid server %q: hostname must match storage account %q in the configured Azure cloud", server, accountName)
+	}
+
+	return nil
+}
+
+func parseInlineVolumeServer(server string) (string, error) {
+	if server == "" {
+		return "", fmt.Errorf("server must not be empty")
+	}
+	if strings.TrimSpace(server) != server {
+		return "", fmt.Errorf("server %q must not contain leading or trailing whitespace", server)
+	}
+
+	serverURL := server
+	hasScheme := strings.Contains(server, "://")
+	if !hasScheme {
+		serverURL = "https://" + server
+	}
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid server %q: %w", server, err)
+	}
+	if hasScheme && !strings.EqualFold(parsed.Scheme, "https") {
+		return "", fmt.Errorf("invalid server %q: only HTTPS endpoints are allowed", server)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("invalid server %q: user information is not allowed", server)
+	}
+	if parsed.Port() != "" {
+		return "", fmt.Errorf("invalid server %q: explicit ports are not allowed", server)
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("invalid server %q: paths are not allowed", server)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid server %q: query strings and fragments are not allowed", server)
+	}
+
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if host == "" {
+		return "", fmt.Errorf("invalid server %q: hostname is required", server)
+	}
+	if net.ParseIP(host) != nil {
+		return "", fmt.Errorf("invalid server %q: IP addresses are not allowed", server)
+	}
+
+	return host, nil
 }
 
 // tokenizeMountOptionsString splits a mountOptions string from volumeAttributes

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1283,53 +1283,71 @@ func ValidateContainerName(containerName string) error {
 	return nil
 }
 
-// ValidateInlineVolumeServer ensures a namespace-controlled inline volume can
-// only direct storage traffic to the resolved account in the configured cloud.
-func ValidateInlineVolumeServer(server, accountName, storageEndpointSuffix string) error {
-	_, err := normalizeInlineVolumeServer(server, accountName, storageEndpointSuffix)
-	return err
-}
-
-func normalizeInlineVolumeServer(server, accountName, storageEndpointSuffix string, accountEndpoints ...string) (string, error) {
+// normalizeInlineVolumeServer parses the server and verifies that its hostname
+// belongs to the selected storage account.
+func normalizeInlineVolumeServer(server, accountName, storageEndpointSuffix string) (string, error) {
 	host, err := parseInlineVolumeServer(server)
 	if err != nil {
 		return "", err
 	}
-	if err := validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix, accountEndpoints...); err != nil {
+	if err := validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix); err != nil {
 		return "", err
 	}
 	return host, nil
 }
 
-func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix string, accountEndpoints ...string) error {
+// validateInlineVolumeServerHost checks the parsed hostname against endpoint
+// formats derived from the selected storage account and configured cloud.
+func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix string) error {
 	account := strings.ToLower(strings.TrimSpace(accountName))
 	suffix := strings.ToLower(strings.Trim(strings.TrimSpace(storageEndpointSuffix), "."))
 	if account == "" || suffix == "" {
 		return fmt.Errorf("cannot validate server %q without a storage account and endpoint suffix", server)
 	}
 
+	secondaryAccount := account + "-secondary"
 	allowedHosts := map[string]struct{}{
-		fmt.Sprintf("%s.blob.%s", account, suffix):             {},
-		fmt.Sprintf("%s.dfs.%s", account, suffix):              {},
-		fmt.Sprintf("%s.privatelink.blob.%s", account, suffix): {},
-		fmt.Sprintf("%s.privatelink.dfs.%s", account, suffix):  {},
+		fmt.Sprintf("%s.blob.%s", account, suffix):                      {},
+		fmt.Sprintf("%s.dfs.%s", account, suffix):                       {},
+		fmt.Sprintf("%s.privatelink.blob.%s", account, suffix):          {},
+		fmt.Sprintf("%s.privatelink.dfs.%s", account, suffix):           {},
+		fmt.Sprintf("%s.blob.%s", secondaryAccount, suffix):             {},
+		fmt.Sprintf("%s.dfs.%s", secondaryAccount, suffix):              {},
+		fmt.Sprintf("%s.privatelink.blob.%s", secondaryAccount, suffix): {},
+		fmt.Sprintf("%s.privatelink.dfs.%s", secondaryAccount, suffix):  {},
 	}
-	for _, endpoint := range accountEndpoints {
-		endpointURL, err := url.Parse(endpoint)
-		if err != nil {
-			continue
-		}
-		if endpointHost := strings.ToLower(strings.TrimSuffix(endpointURL.Hostname(), ".")); endpointHost != "" {
-			allowedHosts[endpointHost] = struct{}{}
-		}
+	if _, ok := allowedHosts[host]; ok {
+		return nil
 	}
-	if _, ok := allowedHosts[host]; !ok {
-		return fmt.Errorf("invalid server %q: hostname must match storage account %q in the configured Azure cloud", server, accountName)
+	if suffix == defaultStorageEndPointSuffix && isAzureDNSZoneStorageHost(host, account) {
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("invalid server %q: hostname must match storage account %q in the configured Azure cloud", server, accountName)
 }
 
+// isAzureDNSZoneStorageHost validates the public Azure DNS-zone endpoint
+// format without requiring a storage management-plane lookup from the node.
+func isAzureDNSZoneStorageHost(host, account string) bool {
+	parts := strings.Split(host, ".")
+	if len(parts) != 6 {
+		return false
+	}
+	if parts[0] != account && parts[0] != account+"-secondary" {
+		return false
+	}
+	zone := parts[1]
+	if len(zone) != 3 || zone[0] != 'z' || zone[1] < '0' || zone[1] > '9' || zone[2] < '0' || zone[2] > '9' {
+		return false
+	}
+	if parts[2] != "blob" && parts[2] != "dfs" {
+		return false
+	}
+	return parts[3] == "storage" && parts[4] == "azure" && parts[5] == "net"
+}
+
+// parseInlineVolumeServer extracts a normalized hostname from an HTTPS server
+// value and rejects URL components that are unsafe for inline volumes.
 func parseInlineVolumeServer(server string) (string, error) {
 	if server == "" {
 		return "", fmt.Errorf("server must not be empty")

--- a/pkg/blob/inline_server_test.go
+++ b/pkg/blob/inline_server_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestValidateInlineVolumeServer(t *testing.T) {
+func TestNormalizeInlineVolumeServerValidation(t *testing.T) {
 	tests := []struct {
 		name     string
 		server   string
@@ -196,12 +196,12 @@ func TestValidateInlineVolumeServer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidateInlineVolumeServer(test.server, test.account, test.suffix)
+			_, err := normalizeInlineVolumeServer(test.server, test.account, test.suffix)
 			if test.expected && err != nil {
-				t.Fatalf("ValidateInlineVolumeServer() returned unexpected error: %v", err)
+				t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
 			}
 			if !test.expected && err == nil {
-				t.Fatal("ValidateInlineVolumeServer() returned nil, expected an error")
+				t.Fatal("normalizeInlineVolumeServer() returned nil, expected an error")
 			}
 		})
 	}
@@ -221,12 +221,7 @@ func TestNormalizeInlineVolumeServer(t *testing.T) {
 	}
 }
 
-func TestNormalizeInlineVolumeServerWithAccountEndpoint(t *testing.T) {
-	accountEndpoints := []string{
-		"https://account.z22.blob.storage.azure.net/",
-		"https://account.z22.dfs.storage.azure.net/",
-		"https://account-secondary.z22.blob.storage.azure.net/",
-	}
+func TestNormalizeInlineVolumeServerWithAzureDNSZoneEndpoint(t *testing.T) {
 	tests := []string{
 		"account.z22.blob.storage.azure.net",
 		"account.z22.dfs.storage.azure.net",
@@ -238,7 +233,6 @@ func TestNormalizeInlineVolumeServerWithAccountEndpoint(t *testing.T) {
 				expected,
 				"account",
 				"core.windows.net",
-				accountEndpoints...,
 			)
 			if err != nil {
 				t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
@@ -250,14 +244,29 @@ func TestNormalizeInlineVolumeServerWithAccountEndpoint(t *testing.T) {
 	}
 }
 
-func TestNormalizeInlineVolumeServerRejectsEndpointNotInAccountMetadata(t *testing.T) {
-	_, err := normalizeInlineVolumeServer(
+func TestNormalizeInlineVolumeServerRejectsInvalidAzureDNSZoneEndpoints(t *testing.T) {
+	tests := []string{
 		"other.z22.blob.storage.azure.net",
+		"account.z2.blob.storage.azure.net",
+		"account.z100.blob.storage.azure.net",
+		"account.z22.file.storage.azure.net",
+		"account.z22.blob.storage.azure.net.example.com",
+	}
+	for _, server := range tests {
+		t.Run(server, func(t *testing.T) {
+			_, err := normalizeInlineVolumeServer(server, "account", "core.windows.net")
+			if err == nil {
+				t.Fatal("normalizeInlineVolumeServer() returned nil, expected an error")
+			}
+		})
+	}
+
+	_, err := normalizeInlineVolumeServer(
+		"account.z22.blob.storage.azure.net",
 		"account",
-		"core.windows.net",
-		"https://account.z22.blob.storage.azure.net/",
+		"core.usgovcloudapi.net",
 	)
 	if err == nil {
-		t.Fatal("normalizeInlineVolumeServer() returned nil, expected an error")
+		t.Fatal("normalizeInlineVolumeServer() accepted a public Azure DNS-zone endpoint for a sovereign cloud")
 	}
 }

--- a/pkg/blob/inline_server_test.go
+++ b/pkg/blob/inline_server_test.go
@@ -223,9 +223,18 @@ func TestNormalizeInlineVolumeServer(t *testing.T) {
 
 func TestNormalizeInlineVolumeServerWithAzureDNSZoneEndpoint(t *testing.T) {
 	tests := []string{
+		"account.z1.blob.storage.azure.net",
+		"account.z9.dfs.storage.azure.net",
+		"account.z00.blob.storage.azure.net",
+		"account.z01.dfs.storage.azure.net",
+		"account.z10.blob.storage.azure.net",
 		"account.z22.blob.storage.azure.net",
 		"account.z22.dfs.storage.azure.net",
-		"account-secondary.z22.blob.storage.azure.net",
+		"account.z99.blob.storage.azure.net",
+		"account.z22.privatelink.blob.storage.azure.net",
+		"account.z22.privatelink.dfs.storage.azure.net",
+		"account-secondary.z22.privatelink.blob.storage.azure.net",
+		"account-secondary.z22.privatelink.dfs.storage.azure.net",
 	}
 	for _, expected := range tests {
 		t.Run(expected, func(t *testing.T) {
@@ -247,9 +256,11 @@ func TestNormalizeInlineVolumeServerWithAzureDNSZoneEndpoint(t *testing.T) {
 func TestNormalizeInlineVolumeServerRejectsInvalidAzureDNSZoneEndpoints(t *testing.T) {
 	tests := []string{
 		"other.z22.blob.storage.azure.net",
-		"account.z2.blob.storage.azure.net",
+		"account.z0.blob.storage.azure.net",
 		"account.z100.blob.storage.azure.net",
 		"account.z22.file.storage.azure.net",
+		"account.z22.privatelink.file.storage.azure.net",
+		"account.z22.other.blob.storage.azure.net",
 		"account.z22.blob.storage.azure.net.example.com",
 	}
 	for _, server := range tests {

--- a/pkg/blob/inline_server_test.go
+++ b/pkg/blob/inline_server_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"testing"
+)
+
+func TestValidateInlineVolumeServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   string
+		account  string
+		suffix   string
+		expected bool
+	}{
+		{
+			name:     "public blob endpoint",
+			server:   "account.blob.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "HTTPS blob endpoint with trailing slash",
+			server:   "https://account.blob.core.windows.net/",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "public DFS endpoint",
+			server:   "account.dfs.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "private link blob endpoint",
+			server:   "account.privatelink.blob.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "private link DFS endpoint",
+			server:   "account.privatelink.dfs.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "sovereign cloud endpoint",
+			server:   "account.blob.core.usgovcloudapi.net",
+			account:  "account",
+			suffix:   "core.usgovcloudapi.net",
+			expected: true,
+		},
+		{
+			name:     "sovereign cloud DFS endpoint",
+			server:   "account.dfs.core.chinacloudapi.cn",
+			account:  "account",
+			suffix:   "core.chinacloudapi.cn",
+			expected: true,
+		},
+		{
+			name:     "case insensitive hostname with trailing dot",
+			server:   "ACCOUNT.BLOB.CORE.WINDOWS.NET.",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:    "empty server",
+			server:  "",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "leading whitespace",
+			server:  " account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "trailing whitespace",
+			server:  "account.blob.core.windows.net ",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "malformed URL",
+			server:  "https://[account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "IPv4 address",
+			server:  "192.0.2.10",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "IPv6 address",
+			server:  "[2001:db8::1]",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "HTTP endpoint",
+			server:  "http://account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "non-HTTPS endpoint",
+			server:  "ftp://account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "different storage account",
+			server:  "other.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "arbitrary subdomain",
+			server:  "account.blob.core.windows.net.example.com",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "userinfo",
+			server:  "https://user@account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "explicit port",
+			server:  "https://account.blob.core.windows.net:443",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "path",
+			server:  "https://account.blob.core.windows.net/container",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "query string",
+			server:  "https://account.blob.core.windows.net/?comp=list",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "fragment",
+			server:  "https://account.blob.core.windows.net/#fragment",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "hostname missing",
+			server:  "https://",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "storage account missing",
+			server:  "account.blob.core.windows.net",
+			account: "",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "endpoint suffix missing",
+			server:  "account.blob.core.windows.net",
+			account: "account",
+			suffix:  "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateInlineVolumeServer(test.server, test.account, test.suffix)
+			if test.expected && err != nil {
+				t.Fatalf("ValidateInlineVolumeServer() returned unexpected error: %v", err)
+			}
+			if !test.expected && err == nil {
+				t.Fatal("ValidateInlineVolumeServer() returned nil, expected an error")
+			}
+		})
+	}
+}
+
+func TestNormalizeInlineVolumeServer(t *testing.T) {
+	server, err := normalizeInlineVolumeServer(
+		"https://ACCOUNT.blob.core.windows.net/",
+		"account",
+		"core.windows.net",
+	)
+	if err != nil {
+		t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
+	}
+	if server != "account.blob.core.windows.net" {
+		t.Fatalf("normalizeInlineVolumeServer() returned %q, expected hostname only", server)
+	}
+}
+
+func TestNormalizeInlineVolumeServerWithAccountEndpoint(t *testing.T) {
+	accountEndpoints := []string{
+		"https://account.z22.blob.storage.azure.net/",
+		"https://account.z22.dfs.storage.azure.net/",
+		"https://account-secondary.z22.blob.storage.azure.net/",
+	}
+	tests := []string{
+		"account.z22.blob.storage.azure.net",
+		"account.z22.dfs.storage.azure.net",
+		"account-secondary.z22.blob.storage.azure.net",
+	}
+	for _, expected := range tests {
+		t.Run(expected, func(t *testing.T) {
+			server, err := normalizeInlineVolumeServer(
+				expected,
+				"account",
+				"core.windows.net",
+				accountEndpoints...,
+			)
+			if err != nil {
+				t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
+			}
+			if server != expected {
+				t.Fatalf("normalizeInlineVolumeServer() returned %q, expected %q", server, expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeInlineVolumeServerRejectsEndpointNotInAccountMetadata(t *testing.T) {
+	_, err := normalizeInlineVolumeServer(
+		"other.z22.blob.storage.azure.net",
+		"account",
+		"core.windows.net",
+		"https://account.z22.blob.storage.azure.net/",
+	)
+	if err == nil {
+		t.Fatal("normalizeInlineVolumeServer() returned nil, expected an error")
+	}
+}

--- a/pkg/blob/inline_server_test.go
+++ b/pkg/blob/inline_server_test.go
@@ -225,8 +225,6 @@ func TestNormalizeInlineVolumeServerWithAzureDNSZoneEndpoint(t *testing.T) {
 	tests := []string{
 		"account.z1.blob.storage.azure.net",
 		"account.z9.dfs.storage.azure.net",
-		"account.z00.blob.storage.azure.net",
-		"account.z01.dfs.storage.azure.net",
 		"account.z10.blob.storage.azure.net",
 		"account.z22.blob.storage.azure.net",
 		"account.z22.dfs.storage.azure.net",
@@ -257,6 +255,8 @@ func TestNormalizeInlineVolumeServerRejectsInvalidAzureDNSZoneEndpoints(t *testi
 	tests := []string{
 		"other.z22.blob.storage.azure.net",
 		"account.z0.blob.storage.azure.net",
+		"account.z00.blob.storage.azure.net",
+		"account.z01.dfs.storage.azure.net",
 		"account.z100.blob.storage.azure.net",
 		"account.z22.file.storage.azure.net",
 		"account.z22.privatelink.file.storage.azure.net",

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -29,7 +29,6 @@ import (
 	volumehelper "sigs.k8s.io/blob-csi-driver/pkg/util"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	"k8s.io/klog/v2"
@@ -430,7 +429,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", targetPath, err)
 	}
 
-	resourceGroup, accountName, _, containerName, authEnv, err := d.GetAuthEnv(ctx, volumeID, protocol, attrib, secrets)
+	_, accountName, _, containerName, authEnv, err := d.GetAuthEnv(ctx, volumeID, protocol, attrib, secrets)
 	if err != nil && !mnt {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
@@ -462,18 +461,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 	if isInlineMSI {
 		originalServerAddress := serverAddress
-		serverAddress, err = parseInlineVolumeServer(originalServerAddress)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
-		}
-		err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix)
-		if err != nil {
-			accountEndpoints, endpointErr := d.getStorageAccountEndpoints(ctx, getValueInMap(attrib, subscriptionIDField), resourceGroup, accountName)
-			if endpointErr != nil {
-				return nil, endpointErr
-			}
-			err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix, accountEndpoints...)
-		}
+		serverAddress, err = normalizeInlineVolumeServer(originalServerAddress, accountName, trustedStorageEndpointSuffix)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
 		}
@@ -674,45 +662,6 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	klog.V(2).Infof("volume(%s) mount on %q succeeded", volumeID, targetPath)
 	isOperationSucceeded = true
 	return &csi.NodeStageVolumeResponse{}, nil
-}
-
-func (d *Driver) getStorageAccountEndpoints(ctx context.Context, subscriptionID, resourceGroup, accountName string) ([]string, error) {
-	if d.cloud == nil || d.cloud.ComputeClientFactory == nil {
-		return nil, fmt.Errorf("cloud account client is not configured")
-	}
-	if subscriptionID == "" {
-		subscriptionID = d.cloud.SubscriptionID
-	}
-	if resourceGroup == "" {
-		resourceGroup = d.cloud.ResourceGroup
-	}
-	accountClient, err := d.cloud.ComputeClientFactory.GetAccountClientForSub(subscriptionID)
-	if err != nil {
-		return nil, err
-	}
-	account, err := accountClient.GetProperties(ctx, resourceGroup, accountName, nil)
-	if err != nil {
-		return nil, err
-	}
-	if account == nil || account.Properties == nil {
-		return nil, fmt.Errorf("storage account %q has no endpoint metadata", accountName)
-	}
-
-	var endpoints []string
-	appendEndpoints := func(storageEndpoints *armstorage.Endpoints) {
-		if storageEndpoints == nil {
-			return
-		}
-		if storageEndpoints.Blob != nil {
-			endpoints = append(endpoints, *storageEndpoints.Blob)
-		}
-		if storageEndpoints.Dfs != nil {
-			endpoints = append(endpoints, *storageEndpoints.Dfs)
-		}
-	}
-	appendEndpoints(account.Properties.PrimaryEndpoints)
-	appendEndpoints(account.Properties.SecondaryEndpoints)
-	return endpoints, nil
 }
 
 // NodeUnstageVolume unmount the volume from the staging path

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -405,12 +405,14 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: containerName must be specified for ephemeral volumes")
 	}
 
+	isInlineMSI := ephemeralVol &&
+		strings.EqualFold(getValueInMap(attrib, storageAuthTypeField), storageAuthTypeMSI)
 	trustedStorageEndpointSuffix := d.getStorageEndPointSuffix()
-	if ephemeralVol {
+	if isInlineMSI {
 		if strings.TrimSpace(storageEndpointSuffix) != "" &&
 			!strings.EqualFold(strings.Trim(storageEndpointSuffix, "."), strings.Trim(trustedStorageEndpointSuffix, ".")) {
 			return nil, status.Errorf(codes.InvalidArgument,
-				"NodeStageVolume: storageEndpointSuffix must match the configured Azure cloud for ephemeral volumes")
+				"NodeStageVolume: storageEndpointSuffix must match the configured Azure cloud for inline MSI volumes")
 		}
 		storageEndpointSuffix = trustedStorageEndpointSuffix
 	}
@@ -458,7 +460,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		// server address is "accountname.blob.core.windows.net" by default
 		serverAddress = fmt.Sprintf("%s.blob.%s", accountName, storageEndpointSuffix)
 	}
-	if ephemeralVol {
+	if isInlineMSI {
 		originalServerAddress := serverAddress
 		serverAddress, err = parseInlineVolumeServer(originalServerAddress)
 		if err != nil {

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -29,6 +29,7 @@ import (
 	volumehelper "sigs.k8s.io/blob-csi-driver/pkg/util"
 	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v2"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	"k8s.io/klog/v2"
@@ -404,6 +405,16 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: containerName must be specified for ephemeral volumes")
 	}
 
+	trustedStorageEndpointSuffix := d.getStorageEndPointSuffix()
+	if ephemeralVol {
+		if strings.TrimSpace(storageEndpointSuffix) != "" &&
+			!strings.EqualFold(strings.Trim(storageEndpointSuffix, "."), strings.Trim(trustedStorageEndpointSuffix, ".")) {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"NodeStageVolume: storageEndpointSuffix must match the configured Azure cloud for ephemeral volumes")
+		}
+		storageEndpointSuffix = trustedStorageEndpointSuffix
+	}
+
 	mc := csiMetrics.NewCSIMetricContext("node_stage_volume").WithBasicVolumeInfo(d.cloud.ResourceGroup, "", d.Name)
 	isOperationSucceeded := false
 	defer func() {
@@ -417,7 +428,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", targetPath, err)
 	}
 
-	_, accountName, _, containerName, authEnv, err := d.GetAuthEnv(ctx, volumeID, protocol, attrib, secrets)
+	resourceGroup, accountName, _, containerName, authEnv, err := d.GetAuthEnv(ctx, volumeID, protocol, attrib, secrets)
 	if err != nil && !mnt {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
@@ -440,12 +451,29 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	if strings.TrimSpace(storageEndpointSuffix) == "" {
-		storageEndpointSuffix = d.getStorageEndPointSuffix()
+		storageEndpointSuffix = trustedStorageEndpointSuffix
 	}
 
 	if strings.TrimSpace(serverAddress) == "" {
 		// server address is "accountname.blob.core.windows.net" by default
 		serverAddress = fmt.Sprintf("%s.blob.%s", accountName, storageEndpointSuffix)
+	}
+	if ephemeralVol {
+		originalServerAddress := serverAddress
+		serverAddress, err = parseInlineVolumeServer(originalServerAddress)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+		}
+		err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix)
+		if err != nil {
+			accountEndpoints, endpointErr := d.getStorageAccountEndpoints(ctx, getValueInMap(attrib, subscriptionIDField), resourceGroup, accountName)
+			if endpointErr == nil {
+				err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix, accountEndpoints...)
+			}
+		}
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+		}
 	}
 
 	if isReadOnlyFromCapability(volumeCapability) {
@@ -643,6 +671,45 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	klog.V(2).Infof("volume(%s) mount on %q succeeded", volumeID, targetPath)
 	isOperationSucceeded = true
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+func (d *Driver) getStorageAccountEndpoints(ctx context.Context, subscriptionID, resourceGroup, accountName string) ([]string, error) {
+	if d.cloud == nil || d.cloud.ComputeClientFactory == nil {
+		return nil, fmt.Errorf("cloud account client is not configured")
+	}
+	if subscriptionID == "" {
+		subscriptionID = d.cloud.SubscriptionID
+	}
+	if resourceGroup == "" {
+		resourceGroup = d.cloud.ResourceGroup
+	}
+	accountClient, err := d.cloud.ComputeClientFactory.GetAccountClientForSub(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	account, err := accountClient.GetProperties(ctx, resourceGroup, accountName, nil)
+	if err != nil {
+		return nil, err
+	}
+	if account == nil || account.Properties == nil {
+		return nil, fmt.Errorf("storage account %q has no endpoint metadata", accountName)
+	}
+
+	var endpoints []string
+	appendEndpoints := func(storageEndpoints *armstorage.Endpoints) {
+		if storageEndpoints == nil {
+			return
+		}
+		if storageEndpoints.Blob != nil {
+			endpoints = append(endpoints, *storageEndpoints.Blob)
+		}
+		if storageEndpoints.Dfs != nil {
+			endpoints = append(endpoints, *storageEndpoints.Dfs)
+		}
+	}
+	appendEndpoints(account.Properties.PrimaryEndpoints)
+	appendEndpoints(account.Properties.SecondaryEndpoints)
+	return endpoints, nil
 }
 
 // NodeUnstageVolume unmount the volume from the staging path

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -469,9 +469,10 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix)
 		if err != nil {
 			accountEndpoints, endpointErr := d.getStorageAccountEndpoints(ctx, getValueInMap(attrib, subscriptionIDField), resourceGroup, accountName)
-			if endpointErr == nil {
-				err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix, accountEndpoints...)
+			if endpointErr != nil {
+				return nil, endpointErr
 			}
+			err = validateInlineVolumeServerHost(originalServerAddress, serverAddress, accountName, trustedStorageEndpointSuffix, accountEndpoints...)
 		}
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -310,6 +310,7 @@ func TestNodePublishVolume(t *testing.T) {
 				// Mock NodeStageVolume to return success
 				d.cloud.ResourceGroup = "rg"
 				d.enableBlobMockMount = true
+				d.allowInlineVolumeKeyAccessWithIdentity = true
 			},
 			req: &csi.NodePublishVolumeRequest{
 				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
@@ -320,9 +321,14 @@ func TestNodePublishVolume(t *testing.T) {
 					"csi.storage.k8s.io/ephemeral":     "true",
 					"csi.storage.k8s.io/pod.namespace": "test-namespace",
 					"containername":                    "test-container", // Add container name to avoid error
+					storageAccountField:                "teststorageaccount",
+					storageAuthTypeField:               storageAuthTypeMSI,
 				},
 			},
 			expectedErr: nil,
+			cleanup: func(d *Driver) {
+				d.allowInlineVolumeKeyAccessWithIdentity = false
+			},
 		},
 		{
 			desc: "Valid request with ephemeral volume and workload identity (clientID) should preserve storageAccount",
@@ -961,6 +967,7 @@ func TestNodeStageVolume(t *testing.T) {
 						containerNameField:    "MyContainer",
 						mountPermissionsField: "0755",
 						protocolField:         "fuse2",
+						serverNameField:       "192.0.2.10",
 					},
 					Secrets: map[string]string{
 						accountKeyField: "fakeKey",
@@ -1006,6 +1013,155 @@ func TestNodeStageVolume(t *testing.T) {
 				}
 				if status.Code(err) != codes.InvalidArgument {
 					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume with IP server is rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+						serverNameField:       "192.0.2.10",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "IP addresses are not allowed") {
+					t.Fatalf("expected error to reject IP addresses, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume with untrusted storage endpoint suffix is rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:             "true",
+						containerNameField:         "container",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						storageEndpointSuffixField: "example.com",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "IP addresses are not allowed") {
+					t.Fatalf("expected error to reject IP addresses, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume with untrusted storage endpoint suffix is rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:             "true",
+						containerNameField:         "container",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						storageEndpointSuffixField: "example.com",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "configured Azure cloud") {
+					t.Fatalf("expected error to reject untrusted endpoint suffix, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "inline volume accepts authoritative storage account endpoint",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:             "true",
+						containerNameField:         "container",
+						mountPermissionsField:      "0755",
+						protocolField:              "nfs",
+						serverNameField:            "acc.z22.blob.storage.azure.net",
+						storageEndpointSuffixField: ".CORE.WINDOWS.NET.",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				endpoint := "https://acc.z22.blob.storage.azure.net/"
+				accountClient := NewMockSAClient(context.Background(), gomock.NewController(t), "", "", "", nil)
+				accountClient.EXPECT().
+					GetProperties(gomock.Any(), "rg", "acc", nil).
+					Return(&armstorage.Account{
+						Properties: &armstorage.AccountProperties{
+							PrimaryEndpoints: &armstorage.Endpoints{Blob: &endpoint},
+						},
+					}, nil)
+				d.cloud.ComputeClientFactory = mock_azclient.NewMockClientFactory(gomock.NewController(t))
+				d.cloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).
+					EXPECT().
+					GetAccountClientForSub(gomock.Any()).
+					Return(accountClient, nil)
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("expected authoritative storage account endpoint to be accepted, got: %v", err)
 				}
 			},
 		},

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -1087,54 +1087,25 @@ func TestNodeStageVolume(t *testing.T) {
 				if status.Code(err) != codes.InvalidArgument {
 					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
 				}
-				if !strings.Contains(err.Error(), "IP addresses are not allowed") {
-					t.Fatalf("expected error to reject IP addresses, got: %v", err)
-				}
-			},
-		},
-		{
-			name: "[Error] inline volume with untrusted storage endpoint suffix is rejected",
-			testFunc: func(t *testing.T) {
-				req := &csi.NodeStageVolumeRequest{
-					VolumeId:          "rg#acc#cont#ns",
-					StagingTargetPath: targetTest,
-					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
-					VolumeContext: map[string]string{
-						ephemeralField:             "true",
-						containerNameField:         "container",
-						mountPermissionsField:      "0755",
-						protocolField:              "fuse2",
-						storageEndpointSuffixField: "example.com",
-					},
-					Secrets: map[string]string{
-						accountKeyField: "fakeKey",
-					},
-				}
-				d := NewFakeDriver()
-				d.cloud.ResourceGroup = "rg"
-
-				_, err := d.NodeStageVolume(context.TODO(), req)
-				if status.Code(err) != codes.InvalidArgument {
-					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
-				}
 				if !strings.Contains(err.Error(), "configured Azure cloud") {
 					t.Fatalf("expected error to reject untrusted endpoint suffix, got: %v", err)
 				}
 			},
 		},
 		{
-			name: "inline volume accepts Azure DNS zone endpoint",
+			name: "inline volume accepts private Azure DNS zone endpoint",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",
 					StagingTargetPath: targetTest,
 					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
 					VolumeContext: map[string]string{
-						ephemeralField:             "true",
-						containerNameField:         "container",
-						mountPermissionsField:      "0755",
-						protocolField:              "nfs",
-						serverNameField:            "acc.z22.blob.storage.azure.net",
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountPermissionsField: "0755",
+						protocolField:         "nfs",
+						serverNameField: "acc.z22.privatelink." +
+							"blob.storage.azure.net",
 						storageEndpointSuffixField: ".CORE.WINDOWS.NET.",
 						storageAuthTypeField:       storageAuthTypeMSI,
 					},
@@ -1151,7 +1122,10 @@ func TestNodeStageVolume(t *testing.T) {
 
 				_, err := d.NodeStageVolume(context.TODO(), req)
 				if err != nil {
-					t.Fatalf("expected Azure DNS zone endpoint to be accepted, got: %v", err)
+					t.Fatalf(
+						"expected private Azure DNS zone endpoint, got: %v",
+						err,
+					)
 				}
 			},
 		},

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -957,18 +957,19 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "non-inline MSI volume skips inline validation",
+			name: "non-inline MSI volume preserves custom server and suffix",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",
 					StagingTargetPath: targetTest,
 					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
 					VolumeContext: map[string]string{
-						containerNameField:    "MyContainer",
-						mountPermissionsField: "0755",
-						protocolField:         "fuse2",
-						serverNameField:       "192.0.2.10",
-						storageAuthTypeField:  storageAuthTypeMSI,
+						containerNameField:         "MyContainer",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						serverNameField:            "192.0.2.10",
+						storageEndpointSuffixField: "example.com",
+						storageAuthTypeField:       storageAuthTypeMSI,
 					},
 					Secrets: map[string]string{
 						accountKeyField: "fakeKey",
@@ -1122,7 +1123,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "inline volume accepts authoritative storage account endpoint",
+			name: "inline volume accepts Azure DNS zone endpoint",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",
@@ -1148,69 +1149,9 @@ func TestNodeStageVolume(t *testing.T) {
 					Exec:      fakeExec,
 				}
 
-				endpoint := "https://acc.z22.blob.storage.azure.net/"
-				accountClient := NewMockSAClient(context.Background(), gomock.NewController(t), "", "", "", nil)
-				accountClient.EXPECT().
-					GetProperties(gomock.Any(), "rg", "acc", nil).
-					Return(&armstorage.Account{
-						Properties: &armstorage.AccountProperties{
-							PrimaryEndpoints: &armstorage.Endpoints{Blob: &endpoint},
-						},
-					}, nil)
-				d.cloud.ComputeClientFactory = mock_azclient.NewMockClientFactory(gomock.NewController(t))
-				d.cloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).
-					EXPECT().
-					GetAccountClientForSub(gomock.Any()).
-					Return(accountClient, nil)
-
 				_, err := d.NodeStageVolume(context.TODO(), req)
 				if err != nil {
-					t.Fatalf("expected authoritative storage account endpoint to be accepted, got: %v", err)
-				}
-			},
-		},
-		{
-			name: "[Error] inline volume propagates storage endpoint lookup failure",
-			testFunc: func(t *testing.T) {
-				req := &csi.NodeStageVolumeRequest{
-					VolumeId:          "rg#acc#cont#ns",
-					StagingTargetPath: targetTest,
-					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
-					VolumeContext: map[string]string{
-						ephemeralField:        "true",
-						containerNameField:    "container",
-						mountPermissionsField: "0755",
-						protocolField:         "nfs",
-						resourceGroupField:    "rg",
-						serverNameField:       "acc.blob.example.com",
-						storageAccountField:   "acc",
-						storageAuthTypeField:  storageAuthTypeMSI,
-					},
-				}
-				d := NewFakeDriver()
-				d.cloud.ResourceGroup = "rg"
-				d.mounter = &mount.SafeFormatAndMount{
-					Interface: &fakeMounter{},
-					Exec:      &testingexec.FakeExec{},
-				}
-
-				endpointErr := errors.New("failed to get storage account endpoints")
-				accountClient := NewMockSAClient(context.Background(), gomock.NewController(t), "", "", "", nil)
-				accountClient.EXPECT().
-					GetProperties(gomock.Any(), "rg", "acc", nil).
-					Return(nil, endpointErr)
-				d.cloud.ComputeClientFactory = mock_azclient.NewMockClientFactory(gomock.NewController(t))
-				d.cloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).
-					EXPECT().
-					GetAccountClientForSub(gomock.Any()).
-					Return(accountClient, nil)
-
-				_, err := d.NodeStageVolume(context.TODO(), req)
-				if !errors.Is(err, endpointErr) {
-					t.Fatalf("expected storage endpoint lookup error, got: %v", err)
-				}
-				if status.Code(err) == codes.InvalidArgument {
-					t.Fatalf("expected lookup failure not to be reported as invalid argument")
+					t.Fatalf("expected Azure DNS zone endpoint to be accepted, got: %v", err)
 				}
 			},
 		},

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -1029,6 +1029,7 @@ func TestNodeStageVolume(t *testing.T) {
 						mountPermissionsField: "0755",
 						protocolField:         "fuse2",
 						serverNameField:       "192.0.2.10",
+						storageAuthTypeField:  storageAuthTypeMSI,
 					},
 					Secrets: map[string]string{
 						accountKeyField: "fakeKey",
@@ -1065,6 +1066,7 @@ func TestNodeStageVolume(t *testing.T) {
 						mountPermissionsField:      "0755",
 						protocolField:              "fuse2",
 						storageEndpointSuffixField: "example.com",
+						storageAuthTypeField:       storageAuthTypeMSI,
 					},
 					Secrets: map[string]string{
 						accountKeyField: "fakeKey",
@@ -1132,6 +1134,7 @@ func TestNodeStageVolume(t *testing.T) {
 						protocolField:              "nfs",
 						serverNameField:            "acc.z22.blob.storage.azure.net",
 						storageEndpointSuffixField: ".CORE.WINDOWS.NET.",
+						storageAuthTypeField:       storageAuthTypeMSI,
 					},
 				}
 				d := NewFakeDriver()
@@ -1162,6 +1165,42 @@ func TestNodeStageVolume(t *testing.T) {
 				_, err := d.NodeStageVolume(context.TODO(), req)
 				if err != nil {
 					t.Fatalf("expected authoritative storage account endpoint to be accepted, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "inline shared-key volume preserves custom server and suffix",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:             "true",
+						containerNameField:         "container",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						serverNameField:            "192.0.2.10",
+						storageEndpointSuffixField: "example.com",
+						storageAuthTypeField:       "key",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("expected inline shared-key custom endpoint to remain supported, got: %v", err)
 				}
 			},
 		},

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -957,7 +957,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "non-inline volume skips containerName validation",
+			name: "non-inline MSI volume skips inline validation",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",
@@ -968,6 +968,7 @@ func TestNodeStageVolume(t *testing.T) {
 						mountPermissionsField: "0755",
 						protocolField:         "fuse2",
 						serverNameField:       "192.0.2.10",
+						storageAuthTypeField:  storageAuthTypeMSI,
 					},
 					Secrets: map[string]string{
 						accountKeyField: "fakeKey",
@@ -1165,6 +1166,51 @@ func TestNodeStageVolume(t *testing.T) {
 				_, err := d.NodeStageVolume(context.TODO(), req)
 				if err != nil {
 					t.Fatalf("expected authoritative storage account endpoint to be accepted, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume propagates storage endpoint lookup failure",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountPermissionsField: "0755",
+						protocolField:         "nfs",
+						resourceGroupField:    "rg",
+						serverNameField:       "acc.blob.example.com",
+						storageAccountField:   "acc",
+						storageAuthTypeField:  storageAuthTypeMSI,
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: &fakeMounter{},
+					Exec:      &testingexec.FakeExec{},
+				}
+
+				endpointErr := errors.New("failed to get storage account endpoints")
+				accountClient := NewMockSAClient(context.Background(), gomock.NewController(t), "", "", "", nil)
+				accountClient.EXPECT().
+					GetProperties(gomock.Any(), "rg", "acc", nil).
+					Return(nil, endpointErr)
+				d.cloud.ComputeClientFactory = mock_azclient.NewMockClientFactory(gomock.NewController(t))
+				d.cloud.ComputeClientFactory.(*mock_azclient.MockClientFactory).
+					EXPECT().
+					GetAccountClientForSub(gomock.Any()).
+					Return(accountClient, nil)
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if !errors.Is(err, endpointErr) {
+					t.Fatalf("expected storage endpoint lookup error, got: %v", err)
+				}
+				if status.Code(err) == codes.InvalidArgument {
+					t.Fatalf("expected lookup failure not to be reported as invalid argument")
 				}
 			},
 		},


### PR DESCRIPTION
Harden server field handling for inline volumes.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Validates inline volume server values against the resolved storage account
and configured cloud environment. Existing PersistentVolume and
StorageClass endpoint behavior remains unchanged.

**Which issue(s) this PR fixes**:

Fixes #

**Requirements**:
- [x] uses conventional commit messages
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

**Release note**:
```release-note
Improve server field validation for inline Blob CSI volumes.
```