### PR TITLE
fix: limit inline block cache parallelism

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -161,6 +161,8 @@ const (
 
 	defaultStorageEndPointSuffix = "core.windows.net"
 
+	maxInlineBlockCacheParallelism = 128
+
 	FSGroupChangeNone = "None"
 	// define tag value delimiter and default is comma
 	tagValueDelimiterField = "tagvaluedelimiter"
@@ -1382,6 +1384,11 @@ func SanitizeMountOptions(mountOptions []string) ([]string, error) {
 		if _, ok := allowedEphemeralMountOptions[flagName]; !ok {
 			return nil, fmt.Errorf("mount option %q is not allowed for ephemeral volumes", flagName)
 		}
+		if flagName == "--block-cache-parallelism" && len(parts) != 2 {
+			return nil, fmt.Errorf(
+				"mount option --block-cache-parallelism requires a value",
+			)
+		}
 		// Validate enum-typed flags when a value is present.
 		if len(parts) == 2 {
 			flagValue := parts[1]
@@ -1394,6 +1401,16 @@ func SanitizeMountOptions(mountOptions []string) ([]string, error) {
 				return nil, fmt.Errorf("mount option %q: value must not contain whitespace", trimmed)
 			}
 			switch flagName {
+			case "--block-cache-parallelism":
+				parallelism, err := strconv.ParseUint(flagValue, 10, 32)
+				if err != nil || parallelism == 0 ||
+					parallelism > maxInlineBlockCacheParallelism {
+					return nil, fmt.Errorf(
+						"mount option --block-cache-parallelism must be "+
+							"between 1 and %d for ephemeral volumes",
+						maxInlineBlockCacheParallelism,
+					)
+				}
 			case "--log-level":
 				if _, ok := allowedLogLevels[flagValue]; !ok {
 					return nil, fmt.Errorf("mount option --log-level has invalid value %q: "+

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1567,6 +1567,37 @@ func TestSanitizeMountOptions(t *testing.T) {
 			expected: []string{"--attr-cache-max-size-mb=256", "--kernel-list-cache-timeout=120"},
 		},
 		{
+			name:     "block-cache parallelism at inline maximum is allowed",
+			options:  []string{"--block-cache-parallelism=128"},
+			wantErr:  false,
+			expected: []string{"--block-cache-parallelism=128"},
+		},
+		{
+			name:    "block-cache parallelism above inline maximum is rejected",
+			options: []string{"--block-cache-parallelism=129"},
+			wantErr: true,
+		},
+		{
+			name:    "block-cache parallelism zero is rejected",
+			options: []string{"--block-cache-parallelism=0"},
+			wantErr: true,
+		},
+		{
+			name:    "block-cache parallelism negative value is rejected",
+			options: []string{"--block-cache-parallelism=-1"},
+			wantErr: true,
+		},
+		{
+			name:    "block-cache parallelism non-numeric value is rejected",
+			options: []string{"--block-cache-parallelism=many"},
+			wantErr: true,
+		},
+		{
+			name:    "block-cache parallelism without value is rejected",
+			options: []string{"--block-cache-parallelism"},
+			wantErr: true,
+		},
+		{
 			name:     "-o FUSE passthrough token is always allowed",
 			options:  []string{"-o allow_other", "--log-level=LOG_WARNING"},
 			wantErr:  false,
@@ -1904,6 +1935,17 @@ func TestSanitizeMountOptionsPipeline(t *testing.T) {
 			input:       "-o allow_other,--file-cache-timeout-in-seconds=240",
 			wantErr:     false,
 			expectedLen: 2,
+		},
+		{
+			name:        "inline block-cache parallelism maximum is allowed",
+			input:       "--block-cache-parallelism=128",
+			wantErr:     false,
+			expectedLen: 1,
+		},
+		{
+			name:    "inline block-cache parallelism above maximum is rejected",
+			input:   "--block-cache-parallelism=1000000",
+			wantErr: true,
 		},
 		{
 			name:    "disallowed flag is blocked via space-separated format",

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -988,9 +988,15 @@ func TestNodeStageVolume(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",
 					StagingTargetPath: targetTest,
-					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeCapability: &csi.VolumeCapability{
+						AccessMode: &volumeCap,
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								MountFlags: []string{"--block-cache-parallelism=129"},
+							},
+						},
+					},
 					VolumeContext: map[string]string{
-						mountOptionsField:     "--block-cache-parallelism=129",
 						mountPermissionsField: "0755",
 						protocolField:         "fuse2",
 					},

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -983,6 +983,75 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "non-inline volume preserves high block-cache parallelism",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						mountOptionsField:     "--block-cache-parallelism=129",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("expected non-inline option to remain supported: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume rejects high block-cache parallelism",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountOptionsField:     "--block-cache-parallelism=129",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "between 1 and 128") {
+					t.Fatalf("expected inline parallelism limit error, got: %v", err)
+				}
+			},
+		},
+		{
 			name: "[Error] conflicting case-variant volume attribute keys are rejected",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{


### PR DESCRIPTION
Limit `--block-cache-parallelism` to values from 1 through 128 when it is supplied through CSI inline volume attributes. The limit matches the BlobFuse2 CLI default. Persistent volume and StorageClass mount options remain unchanged.

Validation:
- Complete `pkg/blob` unit test suite passes.
- Inline value 128 reaches `Running` on AKS.
- Inline value 129 returns `InvalidArgument`.
- Persistent volume value 129 reaches `Running`.