### PR TITLE
cherry-pick #2620 to release-1.27: fix: harden server field handling in inline volume with managed identity auth mount

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1279,6 +1281,140 @@ func ValidateContainerName(containerName string) error {
 		return fmt.Errorf("invalid containerName %q: consecutive hyphens are not allowed", containerName)
 	}
 	return nil
+}
+
+// normalizeInlineVolumeServer parses the server and verifies that its hostname
+// belongs to the selected storage account.
+func normalizeInlineVolumeServer(server, accountName, storageEndpointSuffix string) (string, error) {
+	host, err := parseInlineVolumeServer(server)
+	if err != nil {
+		return "", err
+	}
+	if err := validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix); err != nil {
+		return "", err
+	}
+	return host, nil
+}
+
+// validateInlineVolumeServerHost checks the parsed hostname against endpoint
+// formats derived from the selected storage account and configured cloud.
+func validateInlineVolumeServerHost(server, host, accountName, storageEndpointSuffix string) error {
+	account := strings.ToLower(strings.TrimSpace(accountName))
+	suffix := strings.ToLower(strings.Trim(strings.TrimSpace(storageEndpointSuffix), "."))
+	if account == "" || suffix == "" {
+		return fmt.Errorf("cannot validate server %q without a storage account and endpoint suffix", server)
+	}
+
+	secondaryAccount := account + "-secondary"
+	// Secondary DFS forms are accepted for structural consistency. They do not
+	// currently resolve for HNS accounts because HNS does not support RA-GRS.
+	allowedHosts := map[string]struct{}{
+		fmt.Sprintf("%s.blob.%s", account, suffix):                      {},
+		fmt.Sprintf("%s.dfs.%s", account, suffix):                       {},
+		fmt.Sprintf("%s.privatelink.blob.%s", account, suffix):          {},
+		fmt.Sprintf("%s.privatelink.dfs.%s", account, suffix):           {},
+		fmt.Sprintf("%s.blob.%s", secondaryAccount, suffix):             {},
+		fmt.Sprintf("%s.dfs.%s", secondaryAccount, suffix):              {},
+		fmt.Sprintf("%s.privatelink.blob.%s", secondaryAccount, suffix): {},
+		fmt.Sprintf("%s.privatelink.dfs.%s", secondaryAccount, suffix):  {},
+	}
+	if _, ok := allowedHosts[host]; ok {
+		return nil
+	}
+	if suffix == defaultStorageEndPointSuffix &&
+		isAzureDNSZoneStorageHost(host, account) {
+		return nil
+	}
+
+	return fmt.Errorf("invalid server %q: hostname must match storage account %q in the configured Azure cloud", server, accountName)
+}
+
+// isAzureDNSZoneStorageHost validates the public Azure DNS-zone endpoint
+// format without requiring a storage management-plane lookup from the node.
+func isAzureDNSZoneStorageHost(host, account string) bool {
+	parts := strings.Split(host, ".")
+	if len(parts) != 6 && len(parts) != 7 {
+		return false
+	}
+	if parts[0] != account && parts[0] != account+"-secondary" {
+		return false
+	}
+	zone := parts[1]
+	zoneID, hasZonePrefix := strings.CutPrefix(zone, "z")
+	if !hasZonePrefix {
+		return false
+	}
+	if len(zoneID) == 1 &&
+		(zoneID[0] < '1' || zoneID[0] > '9') {
+		return false
+	}
+	if len(zoneID) == 2 &&
+		(zoneID[0] < '1' || zoneID[0] > '9' ||
+			zoneID[1] < '0' || zoneID[1] > '9') {
+		return false
+	}
+	if len(zoneID) < 1 || len(zoneID) > 2 {
+		return false
+	}
+
+	serviceIndex := 2
+	if len(parts) == 7 {
+		if parts[serviceIndex] != "privatelink" {
+			return false
+		}
+		serviceIndex++
+	}
+	if parts[serviceIndex] != "blob" && parts[serviceIndex] != "dfs" {
+		return false
+	}
+	return strings.Join(parts[serviceIndex+1:], ".") == "storage.azure.net"
+}
+
+// parseInlineVolumeServer extracts a normalized hostname from an HTTPS server
+// value and rejects URL components that are unsafe for inline volumes.
+func parseInlineVolumeServer(server string) (string, error) {
+	if server == "" {
+		return "", fmt.Errorf("server must not be empty")
+	}
+	if strings.TrimSpace(server) != server {
+		return "", fmt.Errorf("server %q must not contain leading or trailing whitespace", server)
+	}
+
+	serverURL := server
+	hasScheme := strings.Contains(server, "://")
+	if !hasScheme {
+		serverURL = "https://" + server
+	}
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid server %q: %w", server, err)
+	}
+	if hasScheme && !strings.EqualFold(parsed.Scheme, "https") {
+		return "", fmt.Errorf("invalid server %q: only HTTPS endpoints are allowed", server)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("invalid server %q: user information is not allowed", server)
+	}
+	if parsed.Port() != "" {
+		return "", fmt.Errorf("invalid server %q: explicit ports are not allowed", server)
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("invalid server %q: paths are not allowed", server)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid server %q: query strings and fragments are not allowed", server)
+	}
+
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if host == "" {
+		return "", fmt.Errorf("invalid server %q: hostname is required", server)
+	}
+	if net.ParseIP(host) != nil {
+		return "", fmt.Errorf("invalid server %q: IP addresses are not allowed", server)
+	}
+
+	return host, nil
 }
 
 // tokenizeMountOptionsString splits a mountOptions string from volumeAttributes

--- a/pkg/blob/inline_server_test.go
+++ b/pkg/blob/inline_server_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blob
+
+import (
+	"testing"
+)
+
+func TestNormalizeInlineVolumeServerValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   string
+		account  string
+		suffix   string
+		expected bool
+	}{
+		{
+			name:     "public blob endpoint",
+			server:   "account.blob.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "HTTPS blob endpoint with trailing slash",
+			server:   "https://account.blob.core.windows.net/",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "public DFS endpoint",
+			server:   "account.dfs.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "private link blob endpoint",
+			server:   "account.privatelink.blob.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "private link DFS endpoint",
+			server:   "account.privatelink.dfs.core.windows.net",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:     "sovereign cloud endpoint",
+			server:   "account.blob.core.usgovcloudapi.net",
+			account:  "account",
+			suffix:   "core.usgovcloudapi.net",
+			expected: true,
+		},
+		{
+			name:     "sovereign cloud DFS endpoint",
+			server:   "account.dfs.core.chinacloudapi.cn",
+			account:  "account",
+			suffix:   "core.chinacloudapi.cn",
+			expected: true,
+		},
+		{
+			name:     "case insensitive hostname with trailing dot",
+			server:   "ACCOUNT.BLOB.CORE.WINDOWS.NET.",
+			account:  "account",
+			suffix:   "core.windows.net",
+			expected: true,
+		},
+		{
+			name:    "empty server",
+			server:  "",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "leading whitespace",
+			server:  " account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "trailing whitespace",
+			server:  "account.blob.core.windows.net ",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "malformed URL",
+			server:  "https://[account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "IPv4 address",
+			server:  "192.0.2.10",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "IPv6 address",
+			server:  "[2001:db8::1]",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "HTTP endpoint",
+			server:  "http://account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "non-HTTPS endpoint",
+			server:  "ftp://account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "different storage account",
+			server:  "other.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "arbitrary subdomain",
+			server:  "account.blob.core.windows.net.example.com",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "userinfo",
+			server:  "https://user@account.blob.core.windows.net",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "explicit port",
+			server:  "https://account.blob.core.windows.net:443",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "path",
+			server:  "https://account.blob.core.windows.net/container",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "query string",
+			server:  "https://account.blob.core.windows.net/?comp=list",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "fragment",
+			server:  "https://account.blob.core.windows.net/#fragment",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "hostname missing",
+			server:  "https://",
+			account: "account",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "storage account missing",
+			server:  "account.blob.core.windows.net",
+			account: "",
+			suffix:  "core.windows.net",
+		},
+		{
+			name:    "endpoint suffix missing",
+			server:  "account.blob.core.windows.net",
+			account: "account",
+			suffix:  "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizeInlineVolumeServer(test.server, test.account, test.suffix)
+			if test.expected && err != nil {
+				t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
+			}
+			if !test.expected && err == nil {
+				t.Fatal("normalizeInlineVolumeServer() returned nil, expected an error")
+			}
+		})
+	}
+}
+
+func TestNormalizeInlineVolumeServer(t *testing.T) {
+	server, err := normalizeInlineVolumeServer(
+		"https://ACCOUNT.blob.core.windows.net/",
+		"account",
+		"core.windows.net",
+	)
+	if err != nil {
+		t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
+	}
+	if server != "account.blob.core.windows.net" {
+		t.Fatalf("normalizeInlineVolumeServer() returned %q, expected hostname only", server)
+	}
+}
+
+func TestNormalizeInlineVolumeServerWithAzureDNSZoneEndpoint(t *testing.T) {
+	tests := []string{
+		"account.z1.blob.storage.azure.net",
+		"account.z9.dfs.storage.azure.net",
+		"account.z10.blob.storage.azure.net",
+		"account.z22.blob.storage.azure.net",
+		"account.z22.dfs.storage.azure.net",
+		"account.z99.blob.storage.azure.net",
+		"account.z22.privatelink.blob.storage.azure.net",
+		"account.z22.privatelink.dfs.storage.azure.net",
+		"account-secondary.z22.privatelink.blob.storage.azure.net",
+		"account-secondary.z22.privatelink.dfs.storage.azure.net",
+	}
+	for _, expected := range tests {
+		t.Run(expected, func(t *testing.T) {
+			server, err := normalizeInlineVolumeServer(
+				expected,
+				"account",
+				"core.windows.net",
+			)
+			if err != nil {
+				t.Fatalf("normalizeInlineVolumeServer() returned unexpected error: %v", err)
+			}
+			if server != expected {
+				t.Fatalf("normalizeInlineVolumeServer() returned %q, expected %q", server, expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeInlineVolumeServerRejectsInvalidAzureDNSZoneEndpoints(t *testing.T) {
+	tests := []string{
+		"other.z22.blob.storage.azure.net",
+		"account.z0.blob.storage.azure.net",
+		"account.z00.blob.storage.azure.net",
+		"account.z01.dfs.storage.azure.net",
+		"account.z100.blob.storage.azure.net",
+		"account.z22.file.storage.azure.net",
+		"account.z22.privatelink.file.storage.azure.net",
+		"account.z22.other.blob.storage.azure.net",
+		"account.z22.blob.storage.azure.net.example.com",
+	}
+	for _, server := range tests {
+		t.Run(server, func(t *testing.T) {
+			_, err := normalizeInlineVolumeServer(server, "account", "core.windows.net")
+			if err == nil {
+				t.Fatal("normalizeInlineVolumeServer() returned nil, expected an error")
+			}
+		})
+	}
+
+	_, err := normalizeInlineVolumeServer(
+		"account.z22.blob.storage.azure.net",
+		"account",
+		"core.usgovcloudapi.net",
+	)
+	if err == nil {
+		t.Fatal("normalizeInlineVolumeServer() accepted a public Azure DNS-zone endpoint for a sovereign cloud")
+	}
+}

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -386,6 +386,18 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: containerName must be specified for ephemeral volumes")
 	}
 
+	isInlineMSI := ephemeralVol &&
+		strings.EqualFold(getValueInMap(attrib, storageAuthTypeField), storageAuthTypeMSI)
+	trustedStorageEndpointSuffix := d.getStorageEndPointSuffix()
+	if isInlineMSI {
+		if strings.TrimSpace(storageEndpointSuffix) != "" &&
+			!strings.EqualFold(strings.Trim(storageEndpointSuffix, "."), strings.Trim(trustedStorageEndpointSuffix, ".")) {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"NodeStageVolume: storageEndpointSuffix must match the configured Azure cloud for inline MSI volumes")
+		}
+		storageEndpointSuffix = trustedStorageEndpointSuffix
+	}
+
 	mc := csiMetrics.NewCSIMetricContext("node_stage_volume").WithBasicVolumeInfo(d.cloud.ResourceGroup, "", d.Name)
 	isOperationSucceeded := false
 	defer func() {
@@ -422,12 +434,19 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	if strings.TrimSpace(storageEndpointSuffix) == "" {
-		storageEndpointSuffix = d.getStorageEndPointSuffix()
+		storageEndpointSuffix = trustedStorageEndpointSuffix
 	}
 
 	if strings.TrimSpace(serverAddress) == "" {
 		// server address is "accountname.blob.core.windows.net" by default
 		serverAddress = fmt.Sprintf("%s.blob.%s", accountName, storageEndpointSuffix)
+	}
+	if isInlineMSI {
+		originalServerAddress := serverAddress
+		serverAddress, err = normalizeInlineVolumeServer(originalServerAddress, accountName, trustedStorageEndpointSuffix)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+		}
 	}
 
 	if isReadOnlyFromCapability(volumeCapability) {

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -283,6 +283,7 @@ func TestNodePublishVolume(t *testing.T) {
 				// Mock NodeStageVolume to return success
 				d.cloud.ResourceGroup = "rg"
 				d.enableBlobMockMount = true
+				d.allowInlineVolumeKeyAccessWithIdentity = true
 			},
 			req: &csi.NodePublishVolumeRequest{
 				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
@@ -293,9 +294,14 @@ func TestNodePublishVolume(t *testing.T) {
 					"csi.storage.k8s.io/ephemeral":     "true",
 					"csi.storage.k8s.io/pod.namespace": "test-namespace",
 					"containername":                    "test-container", // Add container name to avoid error
+					storageAccountField:                "teststorageaccount",
+					storageAuthTypeField:               storageAuthTypeMSI,
 				},
 			},
 			expectedErr: nil,
+			cleanup: func(d *Driver) {
+				d.allowInlineVolumeKeyAccessWithIdentity = false
+			},
 		},
 		{
 			desc: "Valid request with ephemeral volume and workload identity (clientID) should preserve storageAccount",
@@ -924,16 +930,19 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "non-inline volume skips containerName validation",
+			name: "non-inline MSI volume preserves custom server and suffix",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",
 					StagingTargetPath: targetTest,
 					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
 					VolumeContext: map[string]string{
-						containerNameField:    "MyContainer",
-						mountPermissionsField: "0755",
-						protocolField:         "fuse2",
+						containerNameField:         "MyContainer",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						serverNameField:            "192.0.2.10",
+						storageEndpointSuffixField: "example.com",
+						storageAuthTypeField:       storageAuthTypeMSI,
 					},
 					Secrets: map[string]string{
 						accountKeyField: "fakeKey",
@@ -979,6 +988,153 @@ func TestNodeStageVolume(t *testing.T) {
 				}
 				if status.Code(err) != codes.InvalidArgument {
 					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume with IP server is rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+						serverNameField:       "192.0.2.10",
+						storageAuthTypeField:  storageAuthTypeMSI,
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "IP addresses are not allowed") {
+					t.Fatalf("expected error to reject IP addresses, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume with untrusted storage endpoint suffix is rejected",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:             "true",
+						containerNameField:         "container",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						storageEndpointSuffixField: "example.com",
+						storageAuthTypeField:       storageAuthTypeMSI,
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "configured Azure cloud") {
+					t.Fatalf("expected error to reject untrusted endpoint suffix, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "inline volume accepts private Azure DNS zone endpoint",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountPermissionsField: "0755",
+						protocolField:         "nfs",
+						serverNameField: "acc.z22.privatelink." +
+							"blob.storage.azure.net",
+						storageEndpointSuffixField: ".CORE.WINDOWS.NET.",
+						storageAuthTypeField:       storageAuthTypeMSI,
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf(
+						"expected private Azure DNS zone endpoint, got: %v",
+						err,
+					)
+				}
+			},
+		},
+		{
+			name: "inline shared-key volume preserves custom server and suffix",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:             "true",
+						containerNameField:         "container",
+						mountPermissionsField:      "0755",
+						protocolField:              "fuse2",
+						serverNameField:            "192.0.2.10",
+						storageEndpointSuffixField: "example.com",
+						storageAuthTypeField:       "key",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("expected inline shared-key custom endpoint to remain supported, got: %v", err)
 				}
 			},
 		},


### PR DESCRIPTION
Cherry-pick of #2620 to release-1.27.

Original PR: https://github.com/kubernetes-sigs/blob-csi-driver/pull/2620
Original merge commit: fe1f099d41b091e3a8b897484e6f9d0c576b0c9c

## What this fixes
Hardens the `server` / `storageEndpointSuffix` field handling for inline (ephemeral) volumes that authenticate with managed identity (MSI). Validates the endpoint against the configured Azure cloud, supports Azure DNS-zone (Private Link) endpoints (z1–z99), and rejects malformed endpoint shapes. Avoids node-side ARM lookups.

Clean cherry-pick (no conflicts).

/kind bug
/sig storage