### PR TITLE
fix: protect storageAccountName for inline volumes

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -115,6 +115,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 				// only get storage account from secret
 				setKeyValueInMap(context, getAccountKeyFromSecretField, trueValue)
 				setKeyValueInMap(context, storageAccountField, "")
+				setKeyValueInMap(context, storageAccountNameField, "")
 			}
 			if d.canSkipRepublishNodeStage(context, target) {
 				klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) already mounted on %s, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -213,11 +213,17 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:        targetTest,
 				StagingTargetPath: sourceTest,
 				VolumeContext: map[string]string{
-					mountPermissionsField: "0755",
+					mountPermissionsField:   "0755",
+					storageAccountNameField: "persistent-account",
 				},
 				Readonly: true,
 			},
 			expectedErr: nil,
+			postCheck: func(t *testing.T, req *csi.NodePublishVolumeRequest) {
+				if value := getValueInMap(req.VolumeContext, storageAccountNameField); value != "persistent-account" {
+					t.Errorf("expected persistent volume storageAccountName to be preserved, got %q", value)
+				}
+			},
 		},
 		{
 			desc: "Error creating directory",
@@ -322,12 +328,50 @@ func TestNodePublishVolume(t *testing.T) {
 					"csi.storage.k8s.io/pod.namespace": "test-namespace",
 					"containername":                    "test-container", // Add container name to avoid error
 					storageAccountField:                "teststorageaccount",
+					storageAccountNameField:            "teststorageaccount",
 					storageAuthTypeField:               storageAuthTypeMSI,
 				},
 			},
 			expectedErr: nil,
+			postCheck: func(t *testing.T, req *csi.NodePublishVolumeRequest) {
+				if value := getValueInMap(req.VolumeContext, storageAccountNameField); value != "teststorageaccount" {
+					t.Errorf("expected explicitly allowed storageAccountName to be preserved, got %q", value)
+				}
+			},
 			cleanup: func(d *Driver) {
 				d.allowInlineVolumeKeyAccessWithIdentity = false
+			},
+		},
+		{
+			desc: "Ephemeral volume clears both storage account fields when inline identity key access is disabled",
+			setup: func(d *Driver) {
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				VolumeContext: map[string]string{
+					ephemeralField:          trueValue,
+					podNamespaceField:       "test-namespace",
+					containerNameField:      "test-container",
+					storageAccountField:     "canonical-account",
+					storageAccountNameField: "compatibility-account",
+				},
+			},
+			expectedErr: nil,
+			postCheck: func(t *testing.T, req *csi.NodePublishVolumeRequest) {
+				if value := getValueInMap(req.VolumeContext, storageAccountField); value != "" {
+					t.Errorf("expected storageAccount to be cleared, got %q", value)
+				}
+				if value := getValueInMap(req.VolumeContext, storageAccountNameField); value != "" {
+					t.Errorf("expected storageAccountName to be cleared, got %q", value)
+				}
+				if value := getValueInMap(req.VolumeContext, getAccountKeyFromSecretField); value != trueValue {
+					t.Errorf("expected getAccountKeyFromSecret to be true, got %q", value)
+				}
 			},
 		},
 		{
@@ -346,6 +390,7 @@ func TestNodePublishVolume(t *testing.T) {
 					"csi.storage.k8s.io/pod.namespace": "test-namespace",
 					containerNameField:                 "test-container",
 					storageAccountField:                "teststorageaccount",
+					storageAccountNameField:            "teststorageaccount",
 					clientIDField:                      "test-client-id",
 				},
 			},
@@ -353,6 +398,9 @@ func TestNodePublishVolume(t *testing.T) {
 			postCheck: func(t *testing.T, req *csi.NodePublishVolumeRequest) {
 				if sa := req.VolumeContext[storageAccountField]; sa != "teststorageaccount" {
 					t.Errorf("expected storageaccount to be preserved as 'teststorageaccount', got '%s'", sa)
+				}
+				if sa := getValueInMap(req.VolumeContext, storageAccountNameField); sa != "teststorageaccount" {
+					t.Errorf("expected storageAccountName to be preserved as 'teststorageaccount', got '%s'", sa)
 				}
 				if v := req.VolumeContext[getAccountKeyFromSecretField]; v == trueValue {
 					t.Errorf("expected getaccountkeyfromsecret to NOT be forced for WI ephemeral volume, but got 'true'")
@@ -375,6 +423,7 @@ func TestNodePublishVolume(t *testing.T) {
 					"csi.storage.k8s.io/pod.namespace": "test-namespace",
 					containerNameField:                 "test-container",
 					storageAccountField:                "teststorageaccount",
+					storageAccountNameField:            "teststorageaccount",
 					clientIDField:                      "test-client-id",
 					mountWithWITokenField:              trueValue,
 				},
@@ -383,6 +432,9 @@ func TestNodePublishVolume(t *testing.T) {
 			postCheck: func(t *testing.T, req *csi.NodePublishVolumeRequest) {
 				if sa := req.VolumeContext[storageAccountField]; sa != "teststorageaccount" {
 					t.Errorf("expected storageaccount to be preserved as 'teststorageaccount', got '%s'", sa)
+				}
+				if sa := getValueInMap(req.VolumeContext, storageAccountNameField); sa != "teststorageaccount" {
+					t.Errorf("expected storageAccountName to be preserved as 'teststorageaccount', got '%s'", sa)
 				}
 				if v := req.VolumeContext[getAccountKeyFromSecretField]; v == trueValue {
 					t.Errorf("expected getaccountkeyfromsecret to NOT be forced for WI ephemeral volume, but got 'true'")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Clears the compatibility `storageAccountName` field together with `storageAccount` when inline volume key access with the driver identity is disabled. This prevents the alias from bypassing the existing inline-volume protection.

Persistent volumes, workload identity mounts, and clusters that explicitly enable inline volume key access with identity remain unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses conventional commit messages
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Validation**:
- Complete `pkg/blob` unit test suite passes.
- Protected inline volumes clear both account-name fields.
- Persistent volumes preserve `storageAccountName`.
- Workload identity and explicit administrator opt-in paths preserve `storageAccountName`.

**Release note**:
```release-note
Protect the storageAccountName compatibility field for inline volumes.
```