### PR TITLE
fix: block preload for inline volumes

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -268,7 +268,6 @@ var (
 		"--no-symlinks":                    {},
 		"--pool-size":                      {},
 		"--pre-mount-validate":             {},
-		"--preload":                        {},
 		"--preserve-acl":                   {},
 		"--read-only":                      {},
 		"--required-free-space-mb":         {},
@@ -1517,6 +1516,11 @@ func SanitizeMountOptions(mountOptions []string) ([]string, error) {
 		// Extract the flag name: the part before "=" (or the whole token if no "=").
 		parts := strings.SplitN(trimmed, "=", 2)
 		flagName := parts[0]
+		if flagName == "--preload" {
+			return nil, fmt.Errorf(
+				"mount option --preload is not supported for inline volumes; use a StorageClass-based persistent volume instead",
+			)
+		}
 		if _, ok := allowedEphemeralMountOptions[flagName]; !ok {
 			return nil, fmt.Errorf("mount option %q is not allowed for ephemeral volumes", flagName)
 		}

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1609,6 +1609,16 @@ func TestSanitizeMountOptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "--preload is rejected with persistent volume guidance",
+			options: []string{"--preload"},
+			wantErr: true,
+		},
+		{
+			name:    "--preload with value is rejected with persistent volume guidance",
+			options: []string{"--preload=true"},
+			wantErr: true,
+		},
+		{
 			name:    "bare --tmp-path token is rejected (space-separated value)",
 			options: []string{"--tmp-path", "/var/data/cache"},
 			wantErr: true,

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -1082,6 +1082,81 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "non-inline volume preserves preload",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability: &csi.VolumeCapability{
+						AccessMode: &volumeCap,
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								MountFlags: []string{"--preload"},
+							},
+						},
+					},
+					VolumeContext: map[string]string{
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err != nil {
+					t.Fatalf("expected non-inline preload to remain supported: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] inline volume rejects preload with persistent volume guidance",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						containerNameField:    "container",
+						mountOptionsField:     "--preload",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+					Secrets: map[string]string{
+						accountKeyField: "fakeKey",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+				d.enableBlobMockMount = true
+				fakeMounter := &fakeMounter{}
+				fakeExec := &testingexec.FakeExec{}
+				d.mounter = &mount.SafeFormatAndMount{
+					Interface: fakeMounter,
+					Exec:      fakeExec,
+				}
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "use a StorageClass-based persistent volume instead") {
+					t.Fatalf("expected persistent volume guidance, got: %v", err)
+				}
+			},
+		},
+		{
 			name: "[Error] inline volume rejects high block-cache parallelism",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Rejects the BlobFuse2 `--preload` option for inline volumes. Preloading can download the entire container into host storage outside the requesting Pod's ephemeral-storage accounting, allowing an untrusted Pod creator to consume node storage.

The driver returns `InvalidArgument` with guidance to use a StorageClass-based persistent volume instead. Administrator-controlled persistent-volume mount options remain unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [x] uses conventional commit messages
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Validation**:
- Complete `pkg/blob` unit test suite passes.
- Inline `--preload` and `--preload=true` are rejected.
- Persistent-volume `--preload` remains supported through CSI mount flags.

**Release note**:
```release-note
Reject the BlobFuse2 preload option for inline volumes and direct users to StorageClass-based persistent volumes.
```