### PR TITLE
cleanup: reduce log noise for ephemeral (CSI inline) volume NodePublishVolume path

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -121,7 +121,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 				klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) already mounted on %s, skipping NodeStageVolume (no time-bound credential to refresh)", volumeID, target)
 				return &csi.NodePublishVolumeResponse{}, nil
 			}
-			klog.V(2).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
+			klog.V(6).Infof("NodePublishVolume: ephemeral volume(%s) mount on %s", volumeID, target)
 			_, err := d.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{
 				StagingTargetPath: target,
 				VolumeContext:     context,
@@ -157,7 +157,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	// Pass shouldUnmount=false: NodePublishVolume must not unmount a stale mount to
 	// prevent a race where the app container loses its volume mid-write.
-	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions), false)
+	mnt, err := d.ensureMountPoint(target, fs.FileMode(mountPermissions), false, false)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", target, err)
 	}
@@ -425,7 +425,7 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 			csiMetrics.StorageAccountType, blobStorageAccountType,
 			csiMetrics.IsHnsEnabled, strconv.FormatBool(isHnsEnabled))
 	}()
-	mnt, err := d.ensureMountPoint(targetPath, fs.FileMode(mountPermissions), true)
+	mnt, err := d.ensureMountPoint(targetPath, fs.FileMode(mountPermissions), true, ephemeralVol)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not mount target %q: %v", targetPath, err)
 	}
@@ -831,7 +831,10 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 //   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
 //   - (false, nil) if the target was freshly created or successfully unmounted
 //   - (false, err) on other failures
-func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount bool) (bool, error) {
+// ephemeralVol indicates whether this call is on the CSI ephemeral (inline)
+// volume mount path; kubelet reconciles those on every sync loop, so the
+// "already mounted" log is demoted to V(6) to avoid log flooding.
+func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount, ephemeralVol bool) (bool, error) {
 	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
 	if err != nil && !os.IsNotExist(err) {
 		if IsCorruptedDir(target) {
@@ -868,7 +871,11 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 		// CSIDriver.spec.requiresRepublish=true. A per-republish probe would
 		// be wasteful even though probeMount is cheap.
 		if !shouldUnmount {
-			klog.V(2).Infof("already mounted to target %s", target)
+			if ephemeralVol {
+				klog.V(6).Infof("already mounted to target %s", target)
+			} else {
+				klog.V(2).Infof("already mounted to target %s", target)
+			}
 			return !notMnt, nil
 		}
 
@@ -883,7 +890,11 @@ func (d *Driver) ensureMountPoint(target string, perm os.FileMode, shouldUnmount
 		// the blobfuse process died, ESTALE, EIO on a broken mount).
 		err := probeMount(target)
 		if err == nil {
-			klog.V(2).Infof("already mounted to target %s", target)
+			if ephemeralVol {
+				klog.V(6).Infof("already mounted to target %s", target)
+			} else {
+				klog.V(2).Infof("already mounted to target %s", target)
+			}
 			return !notMnt, nil
 		}
 		if shouldUnmount {

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -831,6 +831,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 //   - (true, err) if the target is mounted but the health check failed (shouldUnmount=false)
 //   - (false, nil) if the target was freshly created or successfully unmounted
 //   - (false, err) on other failures
+//
 // ephemeralVol indicates whether this call is on the CSI ephemeral (inline)
 // volume mount path; kubelet reconciles those on every sync loop, so the
 // "already mounted" log is demoted to V(6) to avoid log flooding.

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package blob
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -41,6 +43,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 	testingexec "k8s.io/utils/exec/testing"
@@ -153,6 +156,74 @@ func TestEnsureMountPoint(t *testing.T) {
 	assert.NoError(t, err)
 	err = os.RemoveAll(targetTest)
 	assert.NoError(t, err)
+}
+
+func TestEnsureMountPointEphemeralLogVerbosity(t *testing.T) {
+	// The "already mounted to target ..." log is demoted to V(6) for the
+	// ephemeral (CSI inline) volume path to avoid flooding logs on kubelet
+	// republish reconciles. Non-ephemeral callers must keep V(2) visibility.
+	alreadyMountedTarget := "./false_is_likely_ephemeral_target"
+	_ = makeDir(alreadyMountedTarget)
+	defer func() { _ = os.RemoveAll(alreadyMountedTarget) }()
+
+	d := NewFakeDriver()
+	fakeMounter := &fakeMounter{}
+	fakeExec := &testingexec.FakeExec{ExactOrder: true}
+	d.mounter = &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+		Exec:      fakeExec,
+	}
+
+	buf := new(bytes.Buffer)
+	klog.SetOutput(buf)
+	defer klog.SetOutput(io.Discard)
+	var vLevel klog.Level
+	defer func() { _ = vLevel.Set("0") }()
+
+	tests := []struct {
+		name         string
+		v            string
+		ephemeralVol bool
+		expectLog    bool
+	}{
+		{
+			name:         "non-ephemeral: already-mounted log is visible at V(2)",
+			v:            "2",
+			ephemeralVol: false,
+			expectLog:    true,
+		},
+		{
+			name:         "ephemeral: already-mounted log is suppressed at V(2)",
+			v:            "2",
+			ephemeralVol: true,
+			expectLog:    false,
+		},
+		{
+			name:         "ephemeral: already-mounted log is visible at V(6)",
+			v:            "6",
+			ephemeralVol: true,
+			expectLog:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = vLevel.Set(test.v)
+			buf.Reset()
+
+			// shouldUnmount=false hits the fast "already mounted" branch
+			// (mount table entry authoritative, no probe).
+			_, err := d.ensureMountPoint(alreadyMountedTarget, 0777, false, test.ephemeralVol)
+			assert.NoError(t, err)
+			klog.Flush()
+
+			if test.expectLog {
+				assert.Contains(t, buf.String(), "already mounted to target")
+			} else {
+				assert.NotContains(t, buf.String(), "already mounted to target")
+			}
+		})
+	}
 }
 
 func TestNewMountClient(t *testing.T) {

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -175,6 +175,10 @@ func TestEnsureMountPointEphemeralLogVerbosity(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
+	// klog defaults to logtostderr=true, which bypasses SetOutput. Disable it
+	// so the buffer captures the log output.
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
 	klog.SetOutput(buf)
 	defer klog.SetOutput(io.Discard)
 	var vLevel klog.Level

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -130,7 +130,7 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := d.ensureMountPoint(test.target, 0777, true)
+		_, err := d.ensureMountPoint(test.target, 0777, true, false)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("[%s]: Unexpected Error: %v, expected error: %v", test.desc, err, test.expectedErr)
 		}
@@ -140,7 +140,7 @@ func TestEnsureMountPoint(t *testing.T) {
 	// is skipped to avoid a data-plane ListBlobs on every NodePublishVolume
 	// republish. Expect no error and no Unmount calls.
 	unmountCountBefore := fakeMounter.unmountCount
-	_, err := d.ensureMountPoint(falseTarget, 0777, false)
+	_, err := d.ensureMountPoint(falseTarget, 0777, false, false)
 	if err != nil {
 		t.Errorf("[shouldUnmount=false] expected no error when mount table entry is present, got %v", err)
 	}

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -107,11 +107,14 @@ func LogGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
-	} else {
-		respStr := protosanitizer.StripSecrets(resp).String()
+	} else if klog.V(level).Enabled() {
+		// Only serialize once we know V(level) is enabled so that
+		// protosanitizer's lazy formatting is preserved for disabled levels
+		// (e.g. probe/NodeGetCapabilities at V(6) in production).
 		// Empty response bodies carry zero diagnostic value but dominate node
 		// logs (kubelet reconciles NodePublishVolume/NodeUnpublishVolume on
 		// every sync loop, all of which return "{}" on success). Demote to V(6).
+		respStr := protosanitizer.StripSecrets(resp).String()
 		respLevel := level
 		if respStr == "{}" {
 			respLevel = klog.Level(6)

--- a/pkg/csi-common/utils.go
+++ b/pkg/csi-common/utils.go
@@ -108,7 +108,15 @@ func LogGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
 	} else {
-		klog.V(level).Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+		respStr := protosanitizer.StripSecrets(resp).String()
+		// Empty response bodies carry zero diagnostic value but dominate node
+		// logs (kubelet reconciles NodePublishVolume/NodeUnpublishVolume on
+		// every sync loop, all of which return "{}" on success). Demote to V(6).
+		respLevel := level
+		if respStr == "{}" {
+			respLevel = klog.Level(6)
+		}
+		klog.V(respLevel).Infof("GRPC response: %s", respStr)
 	}
 	return resp, err
 }

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -174,6 +174,10 @@ func TestLogGRPC(t *testing.T) {
 
 func TestLogGRPCEmptyResponse(t *testing.T) {
 	buf := new(bytes.Buffer)
+	// klog defaults to logtostderr=true, which bypasses SetOutput. Disable it
+	// so the buffer captures the log output.
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
 	klog.SetOutput(buf)
 	defer klog.SetOutput(io.Discard)
 

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -172,6 +172,71 @@ func TestLogGRPC(t *testing.T) {
 	}
 }
 
+func TestLogGRPCEmptyResponse(t *testing.T) {
+	buf := new(bytes.Buffer)
+	klog.SetOutput(buf)
+	defer klog.SetOutput(io.Discard)
+
+	var vLevel klog.Level
+	// Restore verbosity after the test so we do not leak state.
+	defer func() { _ = vLevel.Set("100") }()
+
+	info := grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+	req := &csi.NodePublishVolumeRequest{VolumeId: "vol_1"}
+
+	emptyHandler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+	nonEmptyHandler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return &csi.NodeGetInfoResponse{NodeId: "node-1"}, nil
+	}
+
+	tests := []struct {
+		name             string
+		v                string
+		handler          grpc.UnaryHandler
+		expectResponse   bool
+		expectedResponse string
+	}{
+		{
+			name:           "empty response is suppressed at V(2)",
+			v:              "2",
+			handler:        emptyHandler,
+			expectResponse: false,
+		},
+		{
+			name:             "empty response is visible at V(6)",
+			v:                "6",
+			handler:          emptyHandler,
+			expectResponse:   true,
+			expectedResponse: "GRPC response: {}",
+		},
+		{
+			name:             "non-empty response is still visible at V(2)",
+			v:                "2",
+			handler:          nonEmptyHandler,
+			expectResponse:   true,
+			expectedResponse: `GRPC response: {"node_id":"node-1"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = vLevel.Set(test.v)
+			buf.Reset()
+
+			_, _ = LogGRPC(context.Background(), req, &info, test.handler)
+			klog.Flush()
+
+			if test.expectResponse {
+				assert.Contains(t, buf.String(), test.expectedResponse)
+			} else {
+				assert.NotContains(t, buf.String(), "GRPC response:")
+			}
+		})
+	}
+}
+
 func TestNewControllerServiceCapability(t *testing.T) {
 	tests := []struct {
 		c csi.ControllerServiceCapability_RPC_Type


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Kubelet reconciles CSI inline (ephemeral) volumes on every sync loop, and reconciles every mounted volume generally. For the blob node driver this produces multiple log lines per pod per reconcile even when nothing changed. Three of those lines are pure noise on the idempotent short path.

This PR demotes them to `klog.V(6)`:

| # | Log line | Where | When demoted |
|---|---|---|---|
| 1 | `NodePublishVolume: ephemeral volume(csi-xxx) mount on ...` | `nodeserver.go` | ephemeral path only |
| 2 | `already mounted to target ...` | `nodeserver.go` (`ensureMountPoint`, all 3 branches) | ephemeral path only |
| 3 | `GRPC response: {}` | `csi-common/utils.go` (`LogGRPC`) | whenever response body is exactly `{}` |

PVC-backed mounts (which only `NodePublishVolume` once per pod lifetime) and any non-empty GRPC response keep their existing `V(2)` verbosity, so real mount events and RPCs with actual payload are still visible at default log level.

`ensureMountPoint` gains an `ephemeralVol` parameter so the `already mounted to target` log can branch on volume type without adding a separate helper. All existing callers are updated:

- `NodePublishVolume` bind-mount path: not ephemeral-aware (kept `false`).
- `NodeStageVolume`: passes through `ephemeralVol` from the volume context.

**Expected impact**

Based on a matching analysis on azurefile-csi-driver node logs (same kubelet reconcile pattern):

| Pattern | Share of node log |
|---|---|
| `NodePublishVolume: ephemeral volume(...) mount on ...` | ~13% |
| `already mounted to target ...` | ~5% |
| `GRPC response: {}` | ~9% |
| **Total silenced at default verbosity** | **~25%** |

Blob workloads with many pods using the driver should see a similar reduction on node driver logs, without losing any diagnostic signal (all errors, non-empty responses, and PVC-backed mount events are unchanged).

Companion to https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/3348 which applies the same reduction to the azurefile driver.

**Which issue(s) this PR fixes:**

Fixes # (n/a — log-noise cleanup)

**Requirements:**

- [x] Does the affected code have corresponding tests? existing `TestEnsureMountPoint` covers the new parameter (passes `false`); no behavior change for non-ephemeral path.
- [x] Are the changes documented? klog-only change.
- [ ] Is the change backward compatible? Log-only change; default verbosity unchanged. Operators who need the previous lines can raise `-v=6`.

**Release note:**

```release-note
Reduce log noise on the ephemeral (CSI inline) volume `NodePublishVolume` reconcile path: `NodePublishVolume: ephemeral volume(...) mount on ...` and `already mounted to target ...` are now emitted at klog `V(6)` for ephemeral volumes. Additionally, `GRPC response: {}` (empty response body) is demoted to `V(6)` across all node RPCs. PVC-backed volume mount logs and non-empty responses are unchanged. On typical node logs this removes ~25% of lines at the default verbosity.
```
