### PR TITLE
test: add workload identity account-key mode e2e test

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -1273,4 +1273,81 @@ var _ = ginkgo.Describe("[blob-csi-e2e] Dynamic Provisioning", func() {
 		}()
 		test.Run(ctx, cs, defaultNS)
 	})
+
+	ginkgo.It("should create a volume on demand with workload identity account key retrieval [blob.csi.azure.com]", ginkgo.Serial, func(ctx ginkgo.SpecContext) {
+		if !isCapzTest {
+			ginkgo.Skip("test case is only available for CAPZ test")
+		}
+
+		// Wait for background AAD OIDC cache warm-up to finish.
+		ginkgo.By("Waiting for AAD OIDC cache warm-up to complete")
+		<-wiReady
+
+		gomega.Expect(wiClientID).NotTo(gomega.BeEmpty(), "WI client ID not set after background warm-up")
+		gomega.Expect(errWISetup).NotTo(gomega.HaveOccurred(),
+			"background AAD OIDC warm-up failed; WI account key retrieval will not work")
+		clientID := wiClientID
+
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						MountOptions: []string{
+							"-o allow_other",
+							"--file-cache-timeout-in-seconds=120",
+							"--cancel-list-on-mount-seconds=0",
+						},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		// Account-key mode: WI is used to retrieve the storage account key,
+		// then the key is used for the actual mount. No mountWithWorkloadIdentityToken.
+		// Requires Storage Account Contributor role on the managed identity.
+		scParameters := map[string]string{
+			"skuName":  "Premium_LRS",
+			"protocol": "fuse2",
+			"clientID": clientID,
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: scParameters,
+			ServiceAccountName:     wiServiceAccountName,
+		}
+		// Use default namespace because the federated identity credential is bound to
+		// system:serviceaccount:default:<sa-name>, so the SA must be in default namespace.
+		defaultNS, err := cs.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if defaultNS.Labels == nil {
+			defaultNS.Labels = make(map[string]string)
+		}
+		originalEnforce, hadLabel := defaultNS.Labels["pod-security.kubernetes.io/enforce"]
+		defaultNS.Labels["pod-security.kubernetes.io/enforce"] = "privileged"
+		defaultNS, err = cs.CoreV1().Namespaces().Update(ctx, defaultNS, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer func() {
+			nsToRestore, restoreErr := cs.CoreV1().Namespaces().Get(ctx, "default", metav1.GetOptions{})
+			if restoreErr != nil {
+				log.Printf("WARNING: failed to get default namespace for label restore: %v", restoreErr)
+				return
+			}
+			if hadLabel {
+				nsToRestore.Labels["pod-security.kubernetes.io/enforce"] = originalEnforce
+			} else {
+				delete(nsToRestore.Labels, "pod-security.kubernetes.io/enforce")
+			}
+			_, restoreErr = cs.CoreV1().Namespaces().Update(ctx, nsToRestore, metav1.UpdateOptions{})
+			if restoreErr != nil {
+				log.Printf("WARNING: failed to restore pod-security label on default namespace: %v", restoreErr)
+			}
+		}()
+		test.Run(ctx, cs, defaultNS)
+	})
 })

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -293,6 +293,7 @@ const (
 	wiServiceAccountName         = "blob-wi-test-sa"
 	wiServiceAccountNamespace    = "default"
 	wiStorageBlobDataContributor = "ba92f5b4-2d11-453d-a403-e96b0029c9fe" // Storage Blob Data Contributor role GUID
+	wiStorageAccountContributor  = "17d1049b-9a84-46fb-8f53-869881c3d3ab" // Storage Account Contributor role GUID
 )
 
 // configureWorkloadIdentity sets up workload identity resources (fast, sync):
@@ -402,6 +403,14 @@ func configureWorkloadIdentity(ctx context.Context, cs clientset.Interface, azur
 		return "", fmt.Errorf("failed to assign Storage Blob Data Contributor role: %v", err)
 	}
 	log.Printf("Assigned Storage Blob Data Contributor role to identity")
+
+	// Also assign Storage Account Contributor so account-key-mode WI tests
+	// (without mountWithWorkloadIdentityToken) can retrieve storage keys.
+	err = azureClient.AssignRoleToIdentity(ctx, creds.ResourceGroup, identityInfo.PrincipalID, wiStorageAccountContributor)
+	if err != nil {
+		return "", fmt.Errorf("failed to assign Storage Account Contributor role: %v", err)
+	}
+	log.Printf("Assigned Storage Account Contributor role to identity")
 
 	// Skip static sleep for FIC/RBAC propagation — the token exchange retry
 	// loop (waitForAADTokenExchange) naturally handles FIC propagation delay,


### PR DESCRIPTION
## What this PR does / why we need it

The existing workload identity e2e test only covers **token-only mode** (`mountWithWorkloadIdentityToken: "true"` with `Storage Blob Data Contributor` role). This PR adds a new test for the **default account-key mode**, where:

1. The managed identity has `Storage Account Contributor` role
2. The CSI driver uses WI token exchange to authenticate to ARM and retrieve the storage account key
3. The actual blobfuse mount uses the retrieved account key (no OIDC token passed to blobfuse)

This is the more common WI deployment pattern per [workload-identity-static-pv-mount.md](https://github.com/kubernetes-sigs/blob-csi-driver/blob/master/docs/workload-identity-static-pv-mount.md) and does not require `mountWithWorkloadIdentityToken` in StorageClass parameters.

## What's changed

1. **`test/e2e/suite_test.go`**: Add `Storage Account Contributor` role assignment in `configureWorkloadIdentity` (alongside existing `Storage Blob Data Contributor`) so both WI modes are exercised.

2. **`test/e2e/dynamic_provisioning_test.go`**: New Serial test case `"should create a volume on demand with workload identity account key retrieval"` — uses `clientID` in StorageClass parameters without `mountWithWorkloadIdentityToken`, runs in default namespace with the WI-annotated service account.

## Which issue(s) this PR fixes

None — test coverage improvement.

## Release note

```release-note
NONE
```