### PR TITLE
fix: reject non-ASCII volume attribute keys on inline volumes

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	azstorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -1670,6 +1671,25 @@ func ValidateVolumeAttributeKeys(attrib map[string]string) (map[string]string, e
 		seen[lower] = v
 	}
 	return attrib, nil
+}
+
+// ValidateASCIIVolumeAttributeKeys rejects any non-ASCII volume attribute key.
+// Only inline (ephemeral) volume attributes are attacker-controlled, so callers
+// scope this Unicode case-fold-collision guard to that path.
+func ValidateASCIIVolumeAttributeKeys(attrib map[string]string) error {
+	for k := range attrib {
+		for _, c := range []byte(k) {
+			if c >= utf8.RuneSelf {
+				return fmt.Errorf("invalid volume attribute key %q: only ASCII characters are allowed", k)
+			}
+		}
+	}
+	return nil
+}
+
+// isEphemeralVolume checks the reserved key that kubelet adds to inline volumes.
+func isEphemeralVolume(attrib map[string]string) bool {
+	return strings.EqualFold(attrib[ephemeralField], trueValue)
 }
 
 // setKeyValueInMap set key/value pair in map

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -80,9 +80,17 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
+	ephemeral := isEphemeralVolume(context)
 
-	// Validate volume attribute keys: reject maps with case-colliding keys
-	// that carry different values.
+	// Inline volume attributes are attacker-controlled; reject non-ASCII keys
+	// before any lookup or mutation so Unicode/case tricks can't bypass the
+	// ephemeral-volume security guard below.
+	if ephemeral {
+		if err := ValidateASCIIVolumeAttributeKeys(context); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
+		}
+	}
+
 	var err error
 	context, err = ValidateVolumeAttributeKeys(context)
 	if err != nil {
@@ -109,7 +117,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		}
 
 		// ephemeral volume
-		if strings.EqualFold(context[ephemeralField], trueValue) {
+		if ephemeral {
 			setKeyValueInMap(context, secretNamespaceField, context[podNamespaceField])
 			if !d.allowInlineVolumeKeyAccessWithIdentity && !useWorkloadIdentity(context) {
 				// only get storage account from secret
@@ -315,8 +323,15 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	volumeMountGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
 	attrib := req.GetVolumeContext()
 
-	// Validate volume attribute keys: reject maps with case-colliding keys
-	// that carry different values.
+	// Inline volume attributes are attacker-controlled; reject non-ASCII keys
+	// before any lookup or mutation so Unicode/case tricks can't bypass the
+	// ephemeral-volume security guard in NodePublishVolume.
+	if isEphemeralVolume(attrib) {
+		if err := ValidateASCIIVolumeAttributeKeys(attrib); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+		}
+	}
+
 	var err error
 	attrib, err = ValidateVolumeAttributeKeys(attrib)
 	if err != nil {

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -450,6 +450,25 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ephemeral volume rejects Unicode attribute keys before applying the inline guard",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				VolumeContext: map[string]string{
+					ephemeralField:               trueValue,
+					podNamespaceField:            "test-namespace",
+					containerNameField:           "test-container",
+					storageAccountField:          "victim-account",
+					"ſtorageAccount":             "decoy",
+					getAccountKeyFromSecretField: falseValue,
+				},
+			},
+			expectedErr: status.Error(codes.InvalidArgument,
+				`NodePublishVolume: invalid volume attribute key "ſtorageAccount": only ASCII characters are allowed`),
+		},
+		{
 			desc: "Valid request with ephemeral volume and workload identity (clientID) should preserve storageAccount",
 			setup: func(d *Driver) {
 				d.cloud.ResourceGroup = "rg"
@@ -1269,7 +1288,35 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "[Error] conflicting case-variant volume attribute keys are rejected",
+			name: "[Error] conflicting case-variant volume attribute keys are rejected for inline volumes",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						"clientid":            "value-a",
+						"ClientID":            "value-b",
+						containerNameField:    "testcontainer",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err == nil {
+					t.Fatal("expected InvalidArgument error for conflicting case-variant keys, got nil")
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] conflicting case-variant volume attribute keys are rejected for StorageClass-backed volumes",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -928,6 +928,51 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "[Error] ephemeral volume rejects non-ASCII attribute keys",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "unit-test",
+					StagingTargetPath: "unit-test",
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:      trueValue,
+						storageAccountField: "victim-account",
+						"ſtorageAccount":    "decoy",
+					},
+				}
+				d := NewFakeDriver()
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				expectedErr := status.Error(codes.InvalidArgument,
+					`NodeStageVolume: invalid volume attribute key "ſtorageAccount": only ASCII characters are allowed`)
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
+		{
+			name: "persistent volume keeps existing behavior for non-ASCII attribute keys",
+			testFunc: func(t *testing.T) {
+				// No ephemeralField, so the ASCII guard must not run. The request is
+				// made to fail later on mountPermissions instead, which proves the
+				// non-ASCII key was accepted rather than rejected up front.
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "unit-test",
+					StagingTargetPath: "unit-test",
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						"ſtorageAccount":      "decoy",
+						mountPermissionsField: "07ab",
+					},
+				}
+				d := NewFakeDriver()
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				expectedErr := status.Error(codes.InvalidArgument, fmt.Sprintf("invalid mountPermissions %s", "07ab"))
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
+		{
 			name: "[Error] invalid mountPermissions",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{

--- a/pkg/blob/validate_volume_attributes_test.go
+++ b/pkg/blob/validate_volume_attributes_test.go
@@ -72,6 +72,15 @@ func TestValidateVolumeAttributeKeys(t *testing.T) {
 			wantErr: false,
 			wantLen: 3,
 		},
+		{
+			name: "non-ASCII keys retain existing behavior",
+			input: map[string]string{
+				"storageAccount": "myaccount",
+				"ſtorageAccount": "decoy",
+			},
+			wantErr: false,
+			wantLen: 2,
+		},
 	}
 
 	for _, tc := range tests {
@@ -95,6 +104,50 @@ func TestValidateVolumeAttributeKeys(t *testing.T) {
 			}
 			if len(result) != tc.wantLen {
 				t.Errorf("expected %d keys, got %d", tc.wantLen, len(result))
+			}
+		})
+	}
+}
+
+func TestValidateASCIIVolumeAttributeKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "nil map",
+			input: nil,
+		},
+		{
+			name:  "ASCII keys are accepted",
+			input: map[string]string{"clientID": "abc", "containerName": "mycontainer"},
+		},
+		{
+			name: "Unicode key should error",
+			input: map[string]string{
+				"ſtorageAccount": "myaccount",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Unicode case-fold collision should error",
+			input: map[string]string{
+				"storageAccount": "myaccount",
+				"ſtorageAccount": "decoy",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateASCIIVolumeAttributeKeys(tc.input)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Volume attribute key validation uses `strings.ToLower` for duplicate detection, while `getValueInMap`/`setKeyValueInMap` look up and mutate keys with `strings.EqualFold`. The two disagree on non-ASCII input: `ToLower` leaves U+017F (LATIN SMALL LETTER LONG S) unchanged, so `ſtorageAccount` does not collide with `storageaccount`, but `EqualFold` reports the two as equal.

This matters for inline (ephemeral) volumes, where the attributes are pod-author controlled. `NodePublishVolume` blanks `storageAccount`/`storageAccountName` so the account key must come from a Secret. `setKeyValueInMap` only rewrites the *first* `EqualFold` match, and Go map iteration order is randomized, so a Unicode decoy key can absorb that blanking and leave the real attacker-supplied account name in place.

This PR rejects any volume attribute key containing a non-ASCII byte, before any lookup or mutation happens. The check is scoped to inline volumes:

- `ValidateASCIIVolumeAttributeKeys` is new and runs only when `csi.storage.k8s.io/ephemeral` is set.
- The existing `ValidateVolumeAttributeKeys` case-collision check is unchanged and continues to run for **every** volume.
- Persistent volume and StorageClass behaviour is therefore unchanged, including for non-ASCII keys.

**Which issue(s) this PR fixes**:

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [x] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:

Deliberately scoped to inline volumes to avoid a behaviour change for existing persistent volumes. An earlier iteration applied the ASCII check globally and also lowercased accepted keys in place, which changed behaviour for `StorageClass`-provisioned volumes; that was reverted.

Verified on an AKS cluster (v1.35.7) with the driver built from this branch, A/B against a build of `master`:

- Inline volume carrying both `storageaccount` and the `ſtorageaccount` decoy — on `master` the pod reaches `Running`; with this change the mount is refused:
  ```
  MountVolume.SetUp failed for volume "blobvol" : rpc error: code = InvalidArgument
  desc = NodePublishVolume: invalid volume attribute key "ſtorageaccount": only ASCII characters are allowed
  ```
- Inline volume with ordinary ASCII keys still mounts and is read-write.
- Persistent volume carrying a non-ASCII attribute key still mounts and is read-write, confirming the new check does not apply there.

**Release note**:
```
none
```
