### PR TITLE
fix: reject non-ASCII volume attribute keys on inline volumes

### DIFF
--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	azstorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -1636,6 +1637,25 @@ func ValidateVolumeAttributeKeys(attrib map[string]string) (map[string]string, e
 		seen[lower] = v
 	}
 	return attrib, nil
+}
+
+// ValidateASCIIVolumeAttributeKeys rejects any non-ASCII volume attribute key.
+// Only inline (ephemeral) volume attributes are attacker-controlled, so callers
+// scope this Unicode case-fold-collision guard to that path.
+func ValidateASCIIVolumeAttributeKeys(attrib map[string]string) error {
+	for k := range attrib {
+		for _, c := range []byte(k) {
+			if c >= utf8.RuneSelf {
+				return fmt.Errorf("invalid volume attribute key %q: only ASCII characters are allowed", k)
+			}
+		}
+	}
+	return nil
+}
+
+// isEphemeralVolume checks the reserved key that kubelet adds to inline volumes.
+func isEphemeralVolume(attrib map[string]string) bool {
+	return strings.EqualFold(attrib[ephemeralField], trueValue)
 }
 
 // setKeyValueInMap set key/value pair in map

--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -79,6 +79,16 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	mountPermissions := d.mountPermissions
 	context := req.GetVolumeContext()
+	ephemeral := isEphemeralVolume(context)
+
+	// Inline volume attributes are attacker-controlled; reject non-ASCII keys
+	// before any lookup or mutation so Unicode/case tricks can't bypass the
+	// ephemeral-volume security guard below.
+	if ephemeral {
+		if err := ValidateASCIIVolumeAttributeKeys(context); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodePublishVolume: %v", err)
+		}
+	}
 
 	// Validate volume attribute keys: reject maps with case-colliding keys
 	// that carry different values.
@@ -102,7 +112,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		}
 
 		// ephemeral volume
-		if strings.EqualFold(context[ephemeralField], trueValue) {
+		if ephemeral {
 			setKeyValueInMap(context, secretNamespaceField, context[podNamespaceField])
 			// If the caller supplied a clientID or opted into mount-with-WI-token,
 			// this is a workload-identity ephemeral mount: the pod-scoped SA token
@@ -278,6 +288,15 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	mountFlags := req.GetVolumeCapability().GetMount().GetMountFlags()
 	volumeMountGroup := req.GetVolumeCapability().GetMount().GetVolumeMountGroup()
 	attrib := req.GetVolumeContext()
+
+	// Inline volume attributes are attacker-controlled; reject non-ASCII keys
+	// before any lookup or mutation so Unicode/case tricks can't bypass the
+	// ephemeral-volume security guard in NodePublishVolume.
+	if isEphemeralVolume(attrib) {
+		if err := ValidateASCIIVolumeAttributeKeys(attrib); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: %v", err)
+		}
+	}
 
 	// Validate volume attribute keys: reject maps with case-colliding keys
 	// that carry different values.

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -785,6 +785,51 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "[Error] ephemeral volume rejects non-ASCII attribute keys",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "unit-test",
+					StagingTargetPath: "unit-test",
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:      trueValue,
+						storageAccountField: "victim-account",
+						"ſtorageAccount":    "decoy",
+					},
+				}
+				d := NewFakeDriver()
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				expectedErr := status.Error(codes.InvalidArgument,
+					`NodeStageVolume: invalid volume attribute key "ſtorageAccount": only ASCII characters are allowed`)
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
+		{
+			name: "persistent volume keeps existing behavior for non-ASCII attribute keys",
+			testFunc: func(t *testing.T) {
+				// No ephemeralField, so the ASCII guard must not run. The request is
+				// made to fail later on mountPermissions instead, which proves the
+				// non-ASCII key was accepted rather than rejected up front.
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "unit-test",
+					StagingTargetPath: "unit-test",
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						"ſtorageAccount":      "decoy",
+						mountPermissionsField: "07ab",
+					},
+				}
+				d := NewFakeDriver()
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				expectedErr := status.Error(codes.InvalidArgument, fmt.Sprintf("invalid mountPermissions %s", "07ab"))
+				if !reflect.DeepEqual(err, expectedErr) {
+					t.Errorf("actualErr: (%v), expectedErr: (%v)", err, expectedErr)
+				}
+			},
+		},
+		{
 			name: "[Error] invalid mountPermissions",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{

--- a/pkg/blob/nodeserver_test.go
+++ b/pkg/blob/nodeserver_test.go
@@ -372,6 +372,25 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			desc: "Ephemeral volume rejects Unicode attribute keys before applying the inline guard",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:          "vol_1",
+				TargetPath:        targetTest,
+				StagingTargetPath: sourceTest,
+				VolumeContext: map[string]string{
+					ephemeralField:               trueValue,
+					podNamespaceField:            "test-namespace",
+					containerNameField:           "test-container",
+					storageAccountField:          "victim-account",
+					"ſtorageAccount":             "decoy",
+					getAccountKeyFromSecretField: falseValue,
+				},
+			},
+			expectedErr: status.Error(codes.InvalidArgument,
+				`NodePublishVolume: invalid volume attribute key "ſtorageAccount": only ASCII characters are allowed`),
+		},
+		{
 			desc: "Valid request with ephemeral volume and workload identity (clientID) should preserve storageAccount",
 			setup: func(d *Driver) {
 				d.cloud.ResourceGroup = "rg"
@@ -1088,7 +1107,35 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "[Error] conflicting case-variant volume attribute keys are rejected",
+			name: "[Error] conflicting case-variant volume attribute keys are rejected for inline volumes",
+			testFunc: func(t *testing.T) {
+				req := &csi.NodeStageVolumeRequest{
+					VolumeId:          "rg#acc#cont#ns",
+					StagingTargetPath: targetTest,
+					VolumeCapability:  &csi.VolumeCapability{AccessMode: &volumeCap},
+					VolumeContext: map[string]string{
+						ephemeralField:        "true",
+						"clientid":            "value-a",
+						"ClientID":            "value-b",
+						containerNameField:    "testcontainer",
+						mountPermissionsField: "0755",
+						protocolField:         "fuse2",
+					},
+				}
+				d := NewFakeDriver()
+				d.cloud.ResourceGroup = "rg"
+
+				_, err := d.NodeStageVolume(context.TODO(), req)
+				if err == nil {
+					t.Fatal("expected InvalidArgument error for conflicting case-variant keys, got nil")
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("expected codes.InvalidArgument, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "[Error] conflicting case-variant volume attribute keys are rejected for StorageClass-backed volumes",
 			testFunc: func(t *testing.T) {
 				req := &csi.NodeStageVolumeRequest{
 					VolumeId:          "rg#acc#cont#ns",

--- a/pkg/blob/validate_volume_attributes_test.go
+++ b/pkg/blob/validate_volume_attributes_test.go
@@ -72,6 +72,15 @@ func TestValidateVolumeAttributeKeys(t *testing.T) {
 			wantErr: false,
 			wantLen: 3,
 		},
+		{
+			name: "non-ASCII keys retain existing behavior",
+			input: map[string]string{
+				"storageAccount": "myaccount",
+				"ſtorageAccount": "decoy",
+			},
+			wantErr: false,
+			wantLen: 2,
+		},
 	}
 
 	for _, tc := range tests {
@@ -95,6 +104,50 @@ func TestValidateVolumeAttributeKeys(t *testing.T) {
 			}
 			if len(result) != tc.wantLen {
 				t.Errorf("expected %d keys, got %d", tc.wantLen, len(result))
+			}
+		})
+	}
+}
+
+func TestValidateASCIIVolumeAttributeKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "nil map",
+			input: nil,
+		},
+		{
+			name:  "ASCII keys are accepted",
+			input: map[string]string{"clientID": "abc", "containerName": "mycontainer"},
+		},
+		{
+			name: "Unicode key should error",
+			input: map[string]string{
+				"ſtorageAccount": "myaccount",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Unicode case-fold collision should error",
+			input: map[string]string{
+				"storageAccount": "myaccount",
+				"ſtorageAccount": "decoy",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateASCIIVolumeAttributeKeys(tc.input)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- cherry-pick kubernetes-sigs/blob-csi-driver#2679 onto `release-1.26`
- reject non-ASCII volume attribute keys for inline volumes before any lookup or mutation
- keep existing persistent-volume / StorageClass behavior unchanged

## Testing
- not run locally (`go` is not available in this environment)